### PR TITLE
235331-Eligible Outcome Screen Not Displaying The Parents Name

### DIFF
--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible_LA.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible_LA.cshtml
@@ -1,7 +1,8 @@
+@model ParentGuardian
+
 @{
     ViewData["Title"] = "Children eligible";
 }
-@model ParentGuardian
 
 <div class="govuk-grid-column-full">
     @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@


### PR DESCRIPTION
Serialise request into TempData when queuedForProcessing to avoid null request when outcome becomes eligible.

[https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/235331](https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/235331)