### PR TITLE
238048-FSM-ADMIN-HideCookiesSettingsWhenJavaScriptDisabled

### DIFF
--- a/CheckYourEligibility.Admin/Views/Home/Cookies.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Cookies.cshtml
@@ -97,35 +97,37 @@
         </tbody>
     </table>
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l">Change your cookie settings</h2>
-            <form id="cookie-form" action="/form-handler" method="post" novalidate>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                            Do you want to accept analytics cookies?
-                        </legend>
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                                    Yes
-                                </label>
+    <div class="js-only">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h2 class="govuk-heading-l">Change your cookie settings</h2>
+                <form id="cookie-form" action="/form-handler" method="post" novalidate>
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Do you want to accept analytics cookies?
+                            </legend>
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                                        No
+                                    </label>
+                                </div>
                             </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                                    No
-                                </label>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button">
-                    Save cookie settings
-                </button>
-            </form>
+                        </fieldset>
+                    </div>
+                    <button type="submit" class="govuk-button" data-module="govuk-button">
+                        Save cookie settings
+                    </button>
+                </form>
+            </div>
         </div>
     </div>
 </div>

--- a/CheckYourEligibility.Admin/wwwroot/css/site.css
+++ b/CheckYourEligibility.Admin/wwwroot/css/site.css
@@ -66,12 +66,10 @@
     padding-left: 0.875em;
     text-decoration: underline max(1px, 0.0625rem);
 }
-
 /*END - back button overrides */
 
 
 /*BEGIN - Header account links */
-
 #content-header .dfe-header__action-links a,
 #content-header .dfe-header__action-links a:visited,
 #content-header .dfe-header__action-links a:active {
@@ -86,12 +84,10 @@
 .govuk-pagination {
     justify-content: center;
 }
-
 /*END - Header account links */
 
 
 /*BEGIN - Accessible dashboard card links */
-
 .sr-only {
     position: absolute;
     width: 1px;
@@ -102,7 +98,6 @@
     clip: rect(0, 0, 0, 0);
     border: 0;
 }
-
 /*END - Accessible dashboard card links */
 
 
@@ -117,12 +112,10 @@
     .moj-button-menu__item:last-child {
         margin-right: 0;
     }
-
 /* END MENU ITEM */
 
 
 /*BEGIN - Header overrides */
-
 .dfe-header__container {
     padding: 0;
     padding-top: 20px;
@@ -184,18 +177,15 @@ img, svg {
         max-width: 100%;
     }
 }
-
 /*END - Header overrides */
 
 
 /*BEGIN - Child Details form title width extention override */
-
 @media (min-width: 40.0625em) {
     .govuk-summary-list__key {
         width: 45%; /*to fit NIN/ASRN title*/
     }
 }
-
 /*END - Child Details form title width extention override */
 
 body.js-enabled .noJsShow, body:not(.js-enabled) input.noJsRemove {
@@ -203,15 +193,12 @@ body.js-enabled .noJsShow, body:not(.js-enabled) input.noJsRemove {
 }
 
 /*BEGIN - Remove whitespace from ApplicationDetailLA below name and actions */
-
 .whitespaceDelete {
     margin-bottom: 0;
 }
-
 /*END - Remove whitespace from ApplicationDetailLA below name and actions */
 
 /*BEGIN - Inline style replace for search all records design team customised styles */
-
 .govuk-page-header-customisation {
     display: flex;
     align-items: center;
@@ -221,20 +208,15 @@ body.js-enabled .noJsShow, body:not(.js-enabled) input.noJsRemove {
 .govuk-heading-m-customisation {
     margin: 0;
 }
-
 /*END - Inline style replace for search all records design team customised styles */
 
 /*BEGIN - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
-
 .fsm-image {
     min-width: 175px;
 }
-
 /*END - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
 
-
 /*BEGIN - Style a button as a link */
-
 .button-as-link-style {
     background: none;
     border: none;
@@ -243,15 +225,22 @@ body.js-enabled .noJsShow, body:not(.js-enabled) input.noJsRemove {
     cursor: pointer;
     /*    font-size: inherit;*/
 }
-
 /*END - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
 
 /*BEGIN - Align right and set correct margin for 'Remove' link on Evidence Upload Items */
-
 .alignRight {
     text-align: right;
     display: block;
     margin-right: -5px;
 }
-
 /*END - Align right and set correct margin for 'Remove' link on Evidence Upload Items */
+
+/*BEGIN - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */
+.js-only {
+    display: none;
+}
+
+.show {
+    display: block;
+}
+/*END - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */

--- a/CheckYourEligibility.Admin/wwwroot/js/site.js
+++ b/CheckYourEligibility.Admin/wwwroot/js/site.js
@@ -4,6 +4,10 @@ import { initAll } from './govuk-frontend.min.js'
 
 initAll();
 
+//BEGIN-- Can show elements only when JavaScript is enabled by using this class on the element
+document.querySelectorAll('.js-only').forEach(x => x.classList.add("show"))
+//END-- Can show elements only when JavaScript is enabled by using this class on the element
+
 function escapeHtml(unsafe) {
     return unsafe.replace(/[&<>"'`=\/]/g, function (s) {
         return {


### PR DESCRIPTION
Hide the Cookie Consent form for non JS enabled users. Also re-useable JS and CSS for other elements requiring this ability.