### PR TITLE
Elig 2661 clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,6 @@ FodyWeavers.xsd
 # Cypress
 /tests/cypress/downloads/
 /tests/cypress/fixtures/*.json
+/CheckYourEligibility.Admin/CheckYourEligibility.Admin.sln
+/CheckYourEligibility.Admin.Tests/package-lock.json
+/package-lock.json

--- a/CheckYourEligibility.Admin.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/CheckControllerTests.cs
@@ -131,6 +131,43 @@ public class CheckControllerTests : TestBase
     public async Task Enter_Details_Get_When_NoResponseInTempData_Should_ReturnView()
     {
         // Arrange
+        var userId = "test-user-id";
+        var orgId = Guid.NewGuid();
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
+
+        var claims = new List<Claim>
+    {
+        new Claim(ClaimTypes.NameIdentifier, userId),
+        new Claim(ClaimTypes.Email, "test@test.com"),
+        new Claim(ClaimTypes.GivenName, "Test"),
+        new Claim(ClaimTypes.Surname, "User"),
+        new Claim("organisation", organisationJson)
+    };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        _sut.TempData = _tempData;
+
+        var roles = new List<Role>
+    {
+        new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "FSM - Local Authority Role",
+            Code = Constants.RoleCodeLA,
+            NumericId = "123"
+        }
+    };
+
+        _dfeSignInApiServiceCaseMock
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        await _sut.GetDfeClaimsAsync();
+
         var expectedParent = _fixture.Create<ParentGuardian>();
         var expectedErrors = new Dictionary<string, List<string>>();
 
@@ -146,18 +183,55 @@ public class CheckControllerTests : TestBase
         // Assert
         result.Should().BeOfType<ViewResult>();
         var viewResult = result as ViewResult;
-        viewResult.Model.Should().Be(expectedParent);
+        viewResult!.Model.Should().Be(expectedParent);
     }
-
+   
     [Test]
     public async Task Enter_Details_Get_When_ErrorsInTempData_Should_AddToModelState()
     {
         // Arrange
+        var userId = "test-user-id";
+        var orgId = Guid.NewGuid();
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
+
+        var claims = new List<Claim>
+    {
+        new Claim(ClaimTypes.NameIdentifier, userId),
+        new Claim(ClaimTypes.Email, "test@test.com"),
+        new Claim(ClaimTypes.GivenName, "Test"),
+        new Claim(ClaimTypes.Surname, "User"),
+        new Claim("organisation", organisationJson)
+    };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        _sut.TempData = _tempData;
+
+        var roles = new List<Role>
+    {
+        new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "FSM - Local Authority Role",
+            Code = Constants.RoleCodeLA,
+            NumericId = "123"
+        }
+    };
+
+        _dfeSignInApiServiceCaseMock
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        await _sut.GetDfeClaimsAsync();
+
         var expectedParent = _fixture.Create<ParentGuardian>();
         var expectedErrors = new Dictionary<string, List<string>>
-        {
-            { "TestError", new List<string> { "Error message 1", "Error message 2" } }
-        };
+    {
+        { "TestError", new List<string> { "Error message 1", "Error message 2" } }
+    };
 
         _loadParentDetailsUseCaseMock
             .Setup(x => x.Execute(
@@ -171,13 +245,12 @@ public class CheckControllerTests : TestBase
         // Assert
         result.Should().BeOfType<ViewResult>();
         var viewResult = result as ViewResult;
-        viewResult.Model.Should().Be(expectedParent);
+        viewResult!.Model.Should().Be(expectedParent);
 
-        // Verify ModelState contains the expected errors
         _sut.ModelState.ErrorCount.Should().Be(2);
-        _sut.ModelState["TestError"].Errors.Count.Should().Be(2);
-        _sut.ModelState["TestError"].Errors[0].ErrorMessage.Should().Be("Error message 1");
-        _sut.ModelState["TestError"].Errors[1].ErrorMessage.Should().Be("Error message 2");
+        _sut.ModelState["TestError"]!.Errors.Count.Should().Be(2);
+        _sut.ModelState["TestError"]!.Errors[0].ErrorMessage.Should().Be("Error message 1");
+        _sut.ModelState["TestError"]!.Errors[1].ErrorMessage.Should().Be("Error message 2");
     }
 
     [Test]

--- a/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
@@ -1,10 +1,14 @@
-﻿using CheckYourEligibility.Admin.Controllers;
+﻿using CheckYourEligibility.Admin.Boundary.Responses;
+using CheckYourEligibility.Admin.Controllers;
 using CheckYourEligibility.Admin.Domain.DfeSignIn;
+using CheckYourEligibility.Admin.Gateways.Interfaces;
 using CheckYourEligibility.Admin.Infrastructure;
 using CheckYourEligibility.Admin.Models;
+using CheckYourEligibility.Admin.ViewModels;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using System.Security.Claims;
 
@@ -14,37 +18,50 @@ namespace CheckYourEligibility.Admin.Tests.Controllers;
 internal class HomeControllerTests : TestBase
 {
     private Mock<IDfeSignInApiService> _mockDfeSignInApiService;
+    private Mock<ILocalAuthoritySettingsGateway> _mockLocalAuthoritySettingsGateway;
+    private IMemoryCache _memoryCache;
     private HomeController _sut;
 
     [SetUp]
     public void SetUp()
     {
         _mockDfeSignInApiService = new Mock<IDfeSignInApiService>();
-        _sut = new HomeController(_mockDfeSignInApiService.Object);
-		base.SetUp();
-		_sut.ControllerContext.HttpContext = _httpContext.Object;
-		_sut.GetDfeClaimsAsync().Wait();
-	}
+        _mockLocalAuthoritySettingsGateway = new Mock<ILocalAuthoritySettingsGateway>();
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
-	[TearDown]
+        _sut = new HomeController(
+            _mockDfeSignInApiService.Object,
+            _mockLocalAuthoritySettingsGateway.Object,
+            _memoryCache);
+
+        base.SetUp();
+        _sut.ControllerContext.HttpContext = _httpContext.Object;
+        _sut.GetDfeClaimsAsync().Wait();
+    }
+
+    [TearDown]
     public void TearDown()
     {
         _sut.Dispose();
+        _memoryCache.Dispose();
     }
 
     [Test]
     public void Given_Accessibility_LoadsWithEmptyModel()
     {
         // Arrange
-        _mockDfeSignInApiService = new Mock<IDfeSignInApiService>();
-        var controller = new HomeController(_mockDfeSignInApiService.Object);
+        var controller = new HomeController(
+            _mockDfeSignInApiService.Object,
+            _mockLocalAuthoritySettingsGateway.Object,
+            new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         var result = controller.Accessibility();
 
         // Assert
         var viewResult = result as ViewResult;
-        viewResult.ViewName.Should().Be("Accessibility");
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().Be("Accessibility");
         viewResult.Model.Should().BeNull();
     }
 
@@ -52,15 +69,18 @@ internal class HomeControllerTests : TestBase
     public void Given_Privacy_LoadsWithEmptyModel()
     {
         // Arrange
-        _mockDfeSignInApiService = new Mock<IDfeSignInApiService>();
-        var controller = new HomeController(_mockDfeSignInApiService.Object);
+        var controller = new HomeController(
+            _mockDfeSignInApiService.Object,
+            _mockLocalAuthoritySettingsGateway.Object,
+            new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         var result = controller.Privacy();
 
         // Assert
         var viewResult = result as ViewResult;
-        viewResult.ViewName.Should().Be("Privacy");
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().Be("Privacy");
         viewResult.Model.Should().BeNull();
     }
 
@@ -68,143 +88,261 @@ internal class HomeControllerTests : TestBase
     public void Given_Cookies_LoadsWithEmptyModel()
     {
         // Arrange
-        _mockDfeSignInApiService = new Mock<IDfeSignInApiService>();
-        var controller = new HomeController(_mockDfeSignInApiService.Object);
+        var controller = new HomeController(
+            _mockDfeSignInApiService.Object,
+            _mockLocalAuthoritySettingsGateway.Object,
+            new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         var result = controller.Cookies();
 
         // Assert
         var viewResult = result as ViewResult;
-        viewResult.ViewName.Should().Be("Cookies");
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().Be("Cookies");
         viewResult.Model.Should().BeNull();
     }
 
     [Test]
-    public async Task Given_Index_WithValidLocalAuthorityAndRole_ReturnsClaims()
+    public async Task Given_Index_WithValidLocalAuthorityAndRole_ReturnsHomeIndexViewModel()
     {
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
-		var roles = new List<Role>
+
+        var roles = new List<Role>
         {
-            new Role { Id = Guid.NewGuid(), Name = "FSM - Local Authority Role", Code = Constants.RoleCodeLA, NumericId = "123" }
+            new Role
+            {
+                Id = Guid.NewGuid(),
+                Name = "FSM - Local Authority Role",
+                Code = Constants.RoleCodeLA,
+                NumericId = "123"
+            }
         };
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(roles);
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
         await _sut.GetDfeClaimsAsync();
 
-		// Act
-		var result = await _sut.Index();
+        // Act
+        var result = await _sut.Index();
 
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().BeNull();
-        viewResult.Model.Should().BeOfType<DfeClaims>();
-        
-        var dfeClaims = viewResult.Model as DfeClaims;
-        dfeClaims.Roles.Should().HaveCount(1);
-        dfeClaims.Roles[0].Code.Should().Be(Constants.RoleCodeLA);
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.Claims.Roles.Should().HaveCount(1);
+        model.Claims.Roles[0].Code.Should().Be(Constants.RoleCodeLA);
+        model.SchoolCanReviewEvidence.Should().BeFalse();
     }
 
     [Test]
-    public async Task Given_Index_WithValidSchoolAndRole_ReturnsClaims()
+    public async Task Given_Index_WithValidSchoolAndRole_ReturnsHomeIndexViewModel_AndFlagTrue()
     {
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}},\"localAuthority\":{{\"code\":\"893\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
-        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
-		var roles = new List<Role>
-        {
-            new Role { Id = Guid.NewGuid(), Name = "FSM - School Role", Code = Constants.RoleCodeSchool, NumericId = "123" }
-        };
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(roles);
-		await _sut.GetDfeClaimsAsync();
 
-		// Act
-		var result = await _sut.Index();
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var roles = new List<Role>
+        {
+            new Role
+            {
+                Id = Guid.NewGuid(),
+                Name = "FSM - School Role",
+                Code = Constants.RoleCodeSchool,
+                NumericId = "123"
+            }
+        };
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        _mockLocalAuthoritySettingsGateway
+            .Setup(g => g.GetLocalAuthoritySettingsAsync(893))
+            .ReturnsAsync(new LocalAuthoritySettingsResponse
+            {
+                SchoolCanReviewEvidence = true
+            });
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
 
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().BeNull();
-        viewResult.Model.Should().BeOfType<DfeClaims>();
-        
-        var dfeClaims = viewResult.Model as DfeClaims;
-        dfeClaims.Roles.Should().HaveCount(1);
-        dfeClaims.Roles[0].Code.Should().Be(Constants.RoleCodeSchool);
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.Claims.Roles.Should().HaveCount(1);
+        model.Claims.Roles[0].Code.Should().Be(Constants.RoleCodeSchool);
+        model.SchoolCanReviewEvidence.Should().BeTrue();
     }
 
     [Test]
-    public async Task Given_Index_WithValidMATAndRole_ReturnsClaims()
+    public async Task Given_Index_WithValidSchoolAndRole_ReturnsHomeIndexViewModel_AndFlagFalse()
     {
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test MAT\",\"category\":{{\"id\":10,\"name\":\"{Constants.CategoryTypeMAT}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}},\"localAuthority\":{{\"code\":\"893\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-		var roles = new List<Role>
+        var roles = new List<Role>
         {
-            new Role { Id = Guid.NewGuid(), Name = "FSM - MAT Role", Code = Constants.RoleCodeMAT, NumericId = "123" }
+            new Role
+            {
+                Id = Guid.NewGuid(),
+                Name = "FSM - School Role",
+                Code = Constants.RoleCodeSchool,
+                NumericId = "123"
+            }
         };
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(roles);
-		await _sut.GetDfeClaimsAsync();
 
-		// Act
-		var result = await _sut.Index();
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        _mockLocalAuthoritySettingsGateway
+            .Setup(g => g.GetLocalAuthoritySettingsAsync(893))
+            .ReturnsAsync(new LocalAuthoritySettingsResponse
+            {
+                SchoolCanReviewEvidence = false
+            });
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
 
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().BeNull();
-        viewResult.Model.Should().BeOfType<DfeClaims>();
-        
-        var dfeClaims = viewResult.Model as DfeClaims;
-        dfeClaims.Roles.Should().HaveCount(1);
-        dfeClaims.Roles[0].Code.Should().Be(Constants.RoleCodeMAT);
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.Claims.Roles.Should().HaveCount(1);
+        model.Claims.Roles[0].Code.Should().Be(Constants.RoleCodeSchool);
+        model.SchoolCanReviewEvidence.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Given_Index_WithValidMATAndRole_ReturnsHomeIndexViewModel()
+    {
+        // Arrange
+        var userId = "test-user-id";
+        var orgId = Guid.NewGuid();
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test MAT\",\"category\":{{\"id\":10,\"name\":\"{Constants.CategoryTypeMAT}\"}}}}";
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
+            new Claim("organisation", organisationJson)
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var roles = new List<Role>
+        {
+            new Role
+            {
+                Id = Guid.NewGuid(),
+                Name = "FSM - MAT Role",
+                Code = Constants.RoleCodeMAT,
+                NumericId = "123"
+            }
+        };
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.Claims.Roles.Should().HaveCount(1);
+        model.Claims.Roles[0].Code.Should().Be(Constants.RoleCodeMAT);
+        model.SchoolCanReviewEvidence.Should().BeFalse();
     }
 
     [Test]
@@ -213,30 +351,33 @@ internal class HomeControllerTests : TestBase
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test Unknown\",\"category\":{{\"id\":99,\"name\":\"Unknown Type\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test Unknown\",\"category\":{{\"id\":99,\"name\":\"Unknown Type\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
-        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
-		await _sut.GetDfeClaimsAsync();
 
-		// Act
-		var result = await _sut.Index();
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
 
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().Be("UnauthorizedOrganization");
+        viewResult!.ViewName.Should().Be("UnauthorizedOrganization");
     }
 
     [Test]
@@ -245,24 +386,29 @@ internal class HomeControllerTests : TestBase
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-        // Return no roles
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(new List<Role>());
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(new List<Role>());
+
+        await _sut.GetDfeClaimsAsync();
 
         // Act
         var result = await _sut.Index();
@@ -270,7 +416,7 @@ internal class HomeControllerTests : TestBase
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().Be("UnauthorizedRole");
+        viewResult!.ViewName.Should().Be("UnauthorizedRole");
     }
 
     [Test]
@@ -279,28 +425,40 @@ internal class HomeControllerTests : TestBase
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test LA\",\"category\":{{\"id\":2,\"name\":\"{Constants.CategoryTypeLA}\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-        // Return a different role (school role for an LA user)
         var roles = new List<Role>
         {
-            new Role { Id = Guid.NewGuid(), Name = "FSM - School Role", Code = Constants.RoleCodeSchool, NumericId = "456" }
+            new Role
+            {
+                Id = Guid.NewGuid(),
+                Name = "FSM - School Role",
+                Code = Constants.RoleCodeSchool,
+                NumericId = "456"
+            }
         };
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(roles);
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        await _sut.GetDfeClaimsAsync();
 
         // Act
         var result = await _sut.Index();
@@ -308,7 +466,7 @@ internal class HomeControllerTests : TestBase
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().Be("UnauthorizedRole");
+        viewResult!.ViewName.Should().Be("UnauthorizedRole");
     }
 
     [Test]
@@ -317,24 +475,29 @@ internal class HomeControllerTests : TestBase
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}},\"localAuthority\":{{\"code\":\"893\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-        // Return no roles
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(new List<Role>());
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(new List<Role>());
+
+        await _sut.GetDfeClaimsAsync();
 
         // Act
         var result = await _sut.Index();
@@ -342,7 +505,7 @@ internal class HomeControllerTests : TestBase
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().Be("UnauthorizedRole");
+        viewResult!.ViewName.Should().Be("UnauthorizedRole");
     }
 
     [Test]
@@ -351,24 +514,29 @@ internal class HomeControllerTests : TestBase
         // Arrange
         var userId = "test-user-id";
         var orgId = Guid.NewGuid();
-        var organisationJson = $"{{\"id\":\"{orgId}\",\"name\":\"Test MAT\",\"category\":{{\"id\":10,\"name\":\"{Constants.CategoryTypeMAT}\"}}}}";
-        
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test MAT\",\"category\":{{\"id\":10,\"name\":\"{Constants.CategoryTypeMAT}\"}}}}";
+
         var claims = new List<Claim>
         {
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", userId),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "test@test.com"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "Test"),
-            new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "User"),
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, "test@test.com"),
+            new Claim(ClaimTypes.GivenName, "Test"),
+            new Claim(ClaimTypes.Surname, "User"),
             new Claim("organisation", organisationJson)
         };
 
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         var httpContext = new DefaultHttpContext { User = principal };
+
         _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-        // Return no roles
-        _mockDfeSignInApiService.Setup(s => s.GetUserRolesAsync(userId, orgId)).ReturnsAsync(new List<Role>());
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(new List<Role>());
+
+        await _sut.GetDfeClaimsAsync();
 
         // Act
         var result = await _sut.Index();
@@ -376,6 +544,6 @@ internal class HomeControllerTests : TestBase
         // Assert
         var viewResult = result as ViewResult;
         viewResult.Should().NotBeNull();
-        viewResult.ViewName.Should().Be("UnauthorizedRole");
+        viewResult!.ViewName.Should().Be("UnauthorizedRole");
     }
 }

--- a/CheckYourEligibility.Admin/Boundary/Responses/LocalAuthoritySettingsResponse.cs
+++ b/CheckYourEligibility.Admin/Boundary/Responses/LocalAuthoritySettingsResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace CheckYourEligibility.Admin.Boundary.Responses;
+
+public sealed class LocalAuthoritySettingsResponse
+{
+    public bool SchoolCanReviewEvidence { get; set; }
+}

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -128,31 +128,28 @@ public class HomeController : BaseController
             return false;
         }
 
-        var laCode = _Claims?.Organisation?.LocalAuthority?.Code;
-        if (string.IsNullOrWhiteSpace(laCode))
+        var laCodeString = _Claims?.Organisation?.LocalAuthority?.Code;
+        if (!int.TryParse(laCodeString, out var laCode))
         {
             return false;
         }
 
         var cacheKey = $"LocalAuthoritySettings_{laCode}";
 
-        if (_cache.TryGetValue(cacheKey, out LocalAuthoritySettingsResponse? cachedSettings))
+        if (_cache.TryGetValue(cacheKey, out bool cachedValue))
         {
-            return cachedSettings?.SchoolCanReviewEvidence ?? false;
+            return cachedValue;
         }
 
         // ELIG-2661B: cache LA settings before Jenna's MenuProvider builds the school dashboard
-        var localAuthoritySettingsResponse = await _localAuthoritySettingsGateway
-            .GetLocalAuthoritySettingsByLaCode(laCode);
+        var schoolCanReviewEvidence =
+            await _localAuthoritySettingsGateway.GetSchoolCanReviewEvidenceAsync(laCode);
 
-        if (localAuthoritySettingsResponse != null)
-        {
-            _cache.Set(
-                cacheKey,
-                localAuthoritySettingsResponse,
-                TimeSpan.FromMinutes(5));
-        }
+        _cache.Set(
+            cacheKey,
+            schoolCanReviewEvidence,
+            TimeSpan.FromMinutes(5));
 
-        return localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
+        return schoolCanReviewEvidence;
     }
 }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -1,13 +1,24 @@
+using CheckYourEligibility.Admin.Boundary.Responses;
+using CheckYourEligibility.Admin.Gateways.Interfaces;
 using CheckYourEligibility.Admin.Infrastructure;
 using CheckYourEligibility.Admin.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace CheckYourEligibility.Admin.Controllers;
 
 public class HomeController : BaseController
 {
-    public HomeController(IDfeSignInApiService dfeSignInApiService) : base(dfeSignInApiService)
+    private readonly ILocalAuthoritySettingsGateway _localAuthoritySettingsGateway;
+    private readonly IMemoryCache _cache;
+
+    public HomeController(
+        IDfeSignInApiService dfeSignInApiService,
+        ILocalAuthoritySettingsGateway localAuthoritySettingsGateway,
+        IMemoryCache cache) : base(dfeSignInApiService)
     {
+        _localAuthoritySettingsGateway = localAuthoritySettingsGateway;
+        _cache = cache;
     }
 
     public async Task<IActionResult> Index()
@@ -46,9 +57,11 @@ public class HomeController : BaseController
             return View("UnauthorizedRole");
         }
 
+        // ELIG-2661B: populate cached LA settings before MenuProvider builds school menus
+        await CacheLocalAuthoritySettingsForSchoolUser();
+
         return View(_Claims);
     }
-
 
     public IActionResult Privacy()
     {
@@ -69,30 +82,71 @@ public class HomeController : BaseController
     {
         return View("Guidance");
     }
+
     public IActionResult Guidance_Redirect()
     {
         ViewData["Expand"] = "asylum-support";
         return View("Guidance");
     }
+
     public IActionResult Guidance_Basic()
     {
         ViewData["Directory"] = "yes";
         return View("Guidance");
     }
+
     public IActionResult FSMFormDownload()
     {
         return View("FSMFormDownload");
     }
+
     public IActionResult AsylumCheck()
     {
         return View("Guidance_steps/Asylum_Check");
     }
+
     public IActionResult BatchCheck()
     {
         return View("Guidance_steps/Batch_Check");
     }
+
     public IActionResult EvidenceGuidance()
     {
         return View("Guidance_steps/Evidence_Guidance");
+    }
+
+    private async Task CacheLocalAuthoritySettingsForSchoolUser()
+    {
+        var isSchoolUser = _Claims?.Roles?.Any(r =>
+            string.Equals(r.Code, Constants.RoleCodeSchool, StringComparison.OrdinalIgnoreCase)) == true;
+
+        if (!isSchoolUser)
+        {
+            return;
+        }
+
+        var laCode = _Claims?.Organisation?.LocalAuthority?.Code;
+        if (string.IsNullOrWhiteSpace(laCode))
+        {
+            return;
+        }
+
+        var cacheKey = $"LocalAuthoritySettings_{laCode}";
+        if (_cache.TryGetValue(cacheKey, out LocalAuthoritySettingsResponse? _))
+        {
+            return;
+        }
+
+        // ELIG-2661B: cache LA settings for the school's LA so MenuProvider can toggle school review tiles
+        var localAuthoritySettingsResponse = await _localAuthoritySettingsGateway
+            .GetLocalAuthoritySettingsByLaCode(laCode);
+
+        if (localAuthoritySettingsResponse != null)
+        {
+            _cache.Set(
+                cacheKey,
+                localAuthoritySettingsResponse,
+                TimeSpan.FromMinutes(5));
+        }
     }
 }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -2,6 +2,7 @@ using CheckYourEligibility.Admin.Boundary.Responses;
 using CheckYourEligibility.Admin.Gateways.Interfaces;
 using CheckYourEligibility.Admin.Infrastructure;
 using CheckYourEligibility.Admin.Models;
+using CheckYourEligibility.Admin.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -23,14 +24,12 @@ public class HomeController : BaseController
 
     public async Task<IActionResult> Index()
     {
-        // Check if user belongs to an allowed organization type
         var categoryName = _Claims?.Organisation?.Category?.Name;
         if (categoryName == null)
         {
             return View("UnauthorizedOrganization");
         }
 
-        // Determine the required roles based on organization type
         List<string>? requiredRoleCodes = categoryName switch
         {
             Constants.CategoryTypeLA => [Constants.RoleCodeLA, Constants.RoleCodeBasic],
@@ -44,7 +43,6 @@ public class HomeController : BaseController
             return View("UnauthorizedOrganization");
         }
 
-        // Check if user has any of the required roles for their organization type
         bool hasRequiredRole = false;
         if (_Claims.Roles is IEnumerable<dynamic> rolesEnumerable)
         {
@@ -57,10 +55,15 @@ public class HomeController : BaseController
             return View("UnauthorizedRole");
         }
 
-        // ELIG-2661B: populate cached LA settings before MenuProvider builds school menus
-        await CacheLocalAuthoritySettingsForSchoolUser();
+        var schoolCanReviewEvidence = await CacheAndGetSchoolCanReviewEvidence();
 
-        return View(_Claims);
+        var model = new HomeIndexViewModel
+        {
+            Claims = _Claims,
+            SchoolCanReviewEvidence = schoolCanReviewEvidence
+        };
+
+        return View(model);
     }
 
     public IActionResult Privacy()
@@ -115,29 +118,30 @@ public class HomeController : BaseController
         return View("Guidance_steps/Evidence_Guidance");
     }
 
-    private async Task CacheLocalAuthoritySettingsForSchoolUser()
+    private async Task<bool> CacheAndGetSchoolCanReviewEvidence()
     {
         var isSchoolUser = _Claims?.Roles?.Any(r =>
             string.Equals(r.Code, Constants.RoleCodeSchool, StringComparison.OrdinalIgnoreCase)) == true;
 
         if (!isSchoolUser)
         {
-            return;
+            return false;
         }
 
         var laCode = _Claims?.Organisation?.LocalAuthority?.Code;
         if (string.IsNullOrWhiteSpace(laCode))
         {
-            return;
+            return false;
         }
 
         var cacheKey = $"LocalAuthoritySettings_{laCode}";
-        if (_cache.TryGetValue(cacheKey, out LocalAuthoritySettingsResponse? _))
+
+        if (_cache.TryGetValue(cacheKey, out LocalAuthoritySettingsResponse? cachedSettings))
         {
-            return;
+            return cachedSettings?.SchoolCanReviewEvidence ?? false;
         }
 
-        // ELIG-2661B: cache LA settings for the school's LA so MenuProvider can toggle school review tiles
+        // ELIG-2661B: cache LA settings before Jenna's MenuProvider builds the school dashboard
         var localAuthoritySettingsResponse = await _localAuthoritySettingsGateway
             .GetLocalAuthoritySettingsByLaCode(laCode);
 
@@ -148,5 +152,7 @@ public class HomeController : BaseController
                 localAuthoritySettingsResponse,
                 TimeSpan.FromMinutes(5));
         }
+
+        return localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
     }
 }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -46,8 +46,8 @@ public class HomeController : BaseController
         bool hasRequiredRole = false;
         if (_Claims.Roles is IEnumerable<dynamic> rolesEnumerable)
         {
-            hasRequiredRole = rolesEnumerable.Any((Func<dynamic, bool>)(r =>
-                requiredRoleCodes.Any(code => code.Equals(r.Code, StringComparison.OrdinalIgnoreCase))));
+            hasRequiredRole = rolesEnumerable.Any(r =>
+                requiredRoleCodes.Any(code => code.Equals(r.Code, StringComparison.OrdinalIgnoreCase)));
         }
 
         if (!hasRequiredRole)
@@ -66,25 +66,13 @@ public class HomeController : BaseController
         return View(model);
     }
 
-    public IActionResult Privacy()
-    {
-        return View("Privacy");
-    }
+    public IActionResult Privacy() => View("Privacy");
 
-    public IActionResult Accessibility()
-    {
-        return View("Accessibility");
-    }
+    public IActionResult Accessibility() => View("Accessibility");
 
-    public IActionResult Cookies()
-    {
-        return View("Cookies");
-    }
+    public IActionResult Cookies() => View("Cookies");
 
-    public IActionResult Guidance()
-    {
-        return View("Guidance");
-    }
+    public IActionResult Guidance() => View("Guidance");
 
     public IActionResult Guidance_Redirect()
     {
@@ -98,25 +86,13 @@ public class HomeController : BaseController
         return View("Guidance");
     }
 
-    public IActionResult FSMFormDownload()
-    {
-        return View("FSMFormDownload");
-    }
+    public IActionResult FSMFormDownload() => View("FSMFormDownload");
 
-    public IActionResult AsylumCheck()
-    {
-        return View("Guidance_steps/Asylum_Check");
-    }
+    public IActionResult AsylumCheck() => View("Guidance_steps/Asylum_Check");
 
-    public IActionResult BatchCheck()
-    {
-        return View("Guidance_steps/Batch_Check");
-    }
+    public IActionResult BatchCheck() => View("Guidance_steps/Batch_Check");
 
-    public IActionResult EvidenceGuidance()
-    {
-        return View("Guidance_steps/Evidence_Guidance");
-    }
+    public IActionResult EvidenceGuidance() => View("Guidance_steps/Evidence_Guidance");
 
     private async Task<bool> CacheAndGetSchoolCanReviewEvidence()
     {
@@ -129,6 +105,7 @@ public class HomeController : BaseController
         }
 
         var laCodeString = _Claims?.Organisation?.LocalAuthority?.Code;
+
         if (!int.TryParse(laCodeString, out var laCode))
         {
             return false;
@@ -136,20 +113,20 @@ public class HomeController : BaseController
 
         var cacheKey = $"LocalAuthoritySettings_{laCode}";
 
-        if (_cache.TryGetValue(cacheKey, out bool cachedValue))
+        if (_cache.TryGetValue(cacheKey, out LocalAuthoritySettingsResponse? cachedSettings))
         {
-            return cachedValue;
+            return cachedSettings?.SchoolCanReviewEvidence ?? false;
         }
 
-        // ELIG-2661B: cache LA settings before Jenna's MenuProvider builds the school dashboard
-        var schoolCanReviewEvidence =
-            await _localAuthoritySettingsGateway.GetSchoolCanReviewEvidenceAsync(laCode);
+        // ELIG-2661B: cache LA settings before MenuProvider builds school dashboard
+        var localAuthoritySettings =
+            await _localAuthoritySettingsGateway.GetLocalAuthoritySettingsAsync(laCode);
 
-        _cache.Set(
-            cacheKey,
-            schoolCanReviewEvidence,
-            TimeSpan.FromMinutes(5));
+        if (localAuthoritySettings != null)
+        {
+            _cache.Set(cacheKey, localAuthoritySettings, TimeSpan.FromMinutes(5));
+        }
 
-        return schoolCanReviewEvidence;
+        return localAuthoritySettings?.SchoolCanReviewEvidence ?? false;
     }
 }

--- a/CheckYourEligibility.Admin/Domain/DfeSignIn/Organisation.cs
+++ b/CheckYourEligibility.Admin/Domain/DfeSignIn/Organisation.cs
@@ -26,4 +26,12 @@ public sealed class Organisation
 
     [JsonPropertyName("DistrictAdministrative_code")]
     public string DistrictAdministrative_Code { get; set; } = null!;
+    public LocalAuthorityInfo? LocalAuthority { get; set; }
+}
+
+public sealed class LocalAuthorityInfo
+{
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public Guid? Id { get; set; }
 }

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/ILocalAuthoritySettingsGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/ILocalAuthoritySettingsGateway.cs
@@ -1,0 +1,6 @@
+﻿namespace CheckYourEligibility.Admin.Gateways.Interfaces;
+
+public interface ILocalAuthoritySettingsGateway
+{
+    Task<bool> GetSchoolCanReviewEvidenceAsync(int laCode);
+}

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/ILocalAuthoritySettingsGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/ILocalAuthoritySettingsGateway.cs
@@ -1,6 +1,8 @@
-﻿namespace CheckYourEligibility.Admin.Gateways.Interfaces;
+﻿using CheckYourEligibility.Admin.Boundary.Responses;
+
+namespace CheckYourEligibility.Admin.Gateways.Interfaces;
 
 public interface ILocalAuthoritySettingsGateway
 {
-    Task<bool> GetSchoolCanReviewEvidenceAsync(int laCode);
+    Task<LocalAuthoritySettingsResponse?> GetLocalAuthoritySettingsAsync(int laCode);
 }

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -1,4 +1,5 @@
-﻿using CheckYourEligibility.Admin.Domain.DfeSignIn;
+﻿using CheckYourEligibility.Admin.Boundary.Responses;
+using CheckYourEligibility.Admin.Domain.DfeSignIn;
 using CheckYourEligibility.Admin.Models;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -20,17 +21,31 @@ public class MenuProvider : IMenuProvider
         {
             return Array.Empty<MenuItem>();
         }
-        var role = claims.Roles[0].Code;
+        var role = claims.Roles[0].Code;        
 
-        return _cache.GetOrCreate($"Menu_{role}", entry =>
+        // OTG change: School menus depend on Local Authority settings.
+        // Include LA code in cache key so different schools can receive different menus.
+        var laCode = claims.Organisation?.LocalAuthority?.Code ?? "none";
+
+        var cacheKey = role == "fsmSchoolRole"
+            ? $"Menu_{role}_{laCode}"
+            : $"Menu_{role}";
+
+        return _cache.GetOrCreate(cacheKey, entry =>
         {
-            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-            return BuildMenuForRole(role);
+            // Change: shorter cache lifetime so menu reflects LA setting updates sooner
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+
+            return BuildMenuForRole(role, laCode);
         });
     }
 
-    private IEnumerable<MenuItem> BuildMenuForRole(string role)
+    private IEnumerable<MenuItem> BuildMenuForRole(string role, string? laCode)
     {
+        LocalAuthoritySettingsResponse? localAuthoritySettingsResponse = null;
+
+        _cache.TryGetValue($"LocalAuthoritySettings_{laCode}", out localAuthoritySettingsResponse);
+
         switch (role)
         {
             case "fsmMATRole":
@@ -79,7 +94,11 @@ public class MenuProvider : IMenuProvider
                         )
                 };
             case "fsmSchoolRole":
-                return new[] {
+                // Change: school review tiles are controlled by Local Authority settings
+                var schoolCanReviewEvidence = localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
+
+                var schoolMenuItems = new List<MenuItem>
+                {
                     new MenuItem(
                         "Run a check",
                         "Run a check for one parent or guardian",
@@ -93,43 +112,61 @@ public class MenuProvider : IMenuProvider
                         "Run an eligibility check for multiple parents or guardians.",
                         "BulkCheck",
                         "Bulk_Check"
-                        ),
-                    new MenuItem(
-                        "Pending applications",
-                        "Pending applications",
-                        "Check eligibility for children not found in the system.",
-                        "Application",
-                        "PendingApplications"
-                        ),
-                    new MenuItem(
-                        "Finalise applications",
-                        "Finalise applications",
-                        "Finalise applications.",
-                        "Application",
-                        "FinaliseApplications"
-                        ),
+                        )
+                };
+
+                if (schoolCanReviewEvidence)
+                {
+                    schoolMenuItems.Add(
+                        new MenuItem(
+                            "Pending applications",
+                            "Pending applications",
+                            "Check eligibility for children not found in the system.",
+                            "Application",
+                            "PendingApplications"
+                        ));
+
+                    schoolMenuItems.Add(
+                        new MenuItem(
+                            "Finalise applications",
+                            "Finalise applications",
+                            "Finalise applications.",
+                            "Application",
+                            "FinaliseApplications"
+                        ));
+                }
+
+                schoolMenuItems.Add(
                     new MenuItem(
                         "Search",
                         "Search all records",
                         "Search all records and export results.",
                         "Application",
                         "SearchResults"
-                        ),
+                    ));
+
+                schoolMenuItems.Add(
                     new MenuItem(
                         "Download PDF form",
                         "Download PDF form",
                         "Download an eligibility form for parents to complete.",
                         "Home",
                         "FSMFormDownload"
-                        ),
-                    new MenuItem(
-                        "Guidance",
-                        "Guidance for reviewing evidence",
-                        "Read guidance on how to review supporting evidence.",
-                        "Home",
-                        "Guidance"
-                        )
-                };
+                    ));
+
+                if (schoolCanReviewEvidence)
+                {
+                    schoolMenuItems.Add(
+                        new MenuItem(
+                            "Guidance",
+                            "Guidance for reviewing evidence",
+                            "Read guidance on how to review supporting evidence.",
+                            "Home",
+                            "Guidance"
+                        ));
+                }
+
+                return schoolMenuItems;
             case "fsmBasicVersion":
                 return new[] {
                     new MenuItem(

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -21,10 +21,10 @@ public class MenuProvider : IMenuProvider
         {
             return Array.Empty<MenuItem>();
         }
-        var role = claims.Roles[0].Code;        
 
-        // OTG change: School menus depend on Local Authority settings.
-        // Include LA code in cache key so different schools can receive different menus.
+        var role = claims.Roles[0].Code;
+
+        // ELIG-2661B: school menus depend on LA settings, so include LA code in the cache key
         var laCode = claims.Organisation?.LocalAuthority?.Code ?? "none";
 
         var cacheKey = role == "fsmSchoolRole"
@@ -33,68 +33,74 @@ public class MenuProvider : IMenuProvider
 
         return _cache.GetOrCreate(cacheKey, entry =>
         {
-            // Change: shorter cache lifetime so menu reflects LA setting updates sooner
+            // ELIG-2661B: keep this short so school tiles reflect LA setting changes reasonably quickly
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
 
             return BuildMenuForRole(role, laCode);
-        });
+        }) ?? Array.Empty<MenuItem>();
     }
 
     private IEnumerable<MenuItem> BuildMenuForRole(string role, string? laCode)
     {
         LocalAuthoritySettingsResponse? localAuthoritySettingsResponse = null;
 
-        _cache.TryGetValue($"LocalAuthoritySettings_{laCode}", out localAuthoritySettingsResponse);
+        // ELIG-2661B: Jenna moved menu construction here, so read the LA setting from cache at menu-build time
+        if (!string.IsNullOrWhiteSpace(laCode))
+        {
+            _cache.TryGetValue($"LocalAuthoritySettings_{laCode}", out localAuthoritySettingsResponse);
+        }
 
         switch (role)
         {
             case "fsmMATRole":
-                return new[] {
+                return new[]
+                {
                     new MenuItem(
                         "Home",
                         "Home",
                         "Dashboard",
                         "Home",
                         ""
-                        ),
+                    ),
                     new MenuItem(
                         "Run a check",
                         "Run a check for one parent or guardian",
                         "Run an eligibility check for one parent or guardian.",
                         "Check",
                         "Enter_Details"
-                        ),
+                    ),
                     new MenuItem(
                         "Run batch check",
                         "Run a batch check",
                         "Run an eligibility check for multiple parents or guardians.",
                         "BulkCheck",
                         "Bulk_Check"
-                        ),
+                    ),
                     new MenuItem(
                         "Pending applications",
                         "Pending applications",
                         "Check eligibility for children not found in the system.",
                         "Application",
                         "PendingApplications"
-                        ),
+                    ),
                     new MenuItem(
                         "Search",
                         "Search all records",
                         "Search all records and export results.",
                         "Application",
                         "SearchResults"
-                        ),
+                    ),
                     new MenuItem(
                         "Guidance",
                         "Guidance for reviewing evidence",
                         "Read guidance on how to review supporting evidence.",
                         "Home",
                         "Guidance"
-                        )
+                    )
                 };
+
             case "fsmSchoolRole":
-                // Change: school review tiles are controlled by Local Authority settings
+                // ELIG-2661B: school review/finalise/guidance tiles are controlled by the LA setting
                 var schoolCanReviewEvidence = localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
 
                 var schoolMenuItems = new List<MenuItem>
@@ -105,14 +111,14 @@ public class MenuProvider : IMenuProvider
                         "Run an eligibility check for one parent or guardian.",
                         "Check",
                         "Consent_Declaration"
-                        ),
+                    ),
                     new MenuItem(
                         "Run batch check",
                         "Run a batch check",
                         "Run an eligibility check for multiple parents or guardians.",
                         "BulkCheck",
                         "Bulk_Check"
-                        )
+                    )
                 };
 
                 if (schoolCanReviewEvidence)
@@ -167,83 +173,89 @@ public class MenuProvider : IMenuProvider
                 }
 
                 return schoolMenuItems;
+
             case "fsmBasicVersion":
-                return new[] {
+                return new[]
+                {
                     new MenuItem(
                         "Run a check",
                         "Run a check for one parent or guardian",
                         "Run an eligibility check for one parent or guardian.",
                         "Check",
                         "Enter_Details_Basic"
-                        ),
+                    ),
                     new MenuItem(
                         "Run batch check",
                         "Run a batch check",
                         "Run an eligibility check for multiple parents or guardians.",
                         "BulkCheckFsmBasic",
                         "Bulk_Check_FSMB"
-                        ),
+                    ),
                     new MenuItem(
                         "Reports",
                         "Reports",
                         "Generate reports and view recent checks carried out using this service.",
                         "Check",
                         "Reports"
-                        ),
+                    ),
                     new MenuItem(
                         "Guidance",
                         "Guidance",
                         "Read guidance on using this service, reviewing evidence and completing checks for parents claiming asylum.",
                         "Home",
                         "Guidance_Basic"
-                        ),
+                    ),
                     new MenuItem(
                         "Download PDF form",
                         "Download PDF form",
                         "Download an eligibility form for parents to complete.",
                         "Home",
                         "FSMFormDownload"
-                        )
+                    )
                 };
+
             case "fsmLocalAuthority":
-                return new[] {
+                return new[]
+                {
                     new MenuItem(
                         "Run a check",
                         "Run a check for one parent or guardian",
                         "Run an eligibility check for one parent or guardian.",
                         "Check",
                         "Enter_Details"
-                        ),
+                    ),
                     new MenuItem(
                         "Run batch check",
                         "Run a batch check",
                         "Run an eligibility check for multiple parents or guardians.",
                         "BulkCheck",
                         "Bulk_Check"
-                        ),
+                    ),
                     new MenuItem(
                         "Pending applications",
                         "Pending applications",
                         "Check eligibility for children not found in the system.",
                         "Application",
                         "PendingApplications"
-                        ),
+                    ),
                     new MenuItem(
                         "Search",
                         "Search all records",
                         "Search all records and export results.",
                         "Application",
                         "SearchResults"
-                        ),
+                    ),
                     new MenuItem(
                         "Guidance",
                         "Guidance for reviewing evidence",
                         "Read guidance on how to review supporting evidence.",
                         "Home",
                         "Guidance"
-                        )
+                    )
                 };
-            default: return Enumerable.Empty<MenuItem>();
+
+            default:
+                return Enumerable.Empty<MenuItem>();
         }
     }
 }

--- a/CheckYourEligibility.Admin/Gateways/LocalAuthoritySettingsGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/LocalAuthoritySettingsGateway.cs
@@ -1,0 +1,26 @@
+﻿using CheckYourEligibility.Admin.Boundary.Responses;
+using CheckYourEligibility.Admin.Gateways.Interfaces;
+
+namespace CheckYourEligibility.Admin.Gateways;
+
+public sealed class LocalAuthoritySettingsGateway : BaseGateway, ILocalAuthoritySettingsGateway
+{
+
+
+    public LocalAuthoritySettingsGateway(
+        ILoggerFactory logger,
+        HttpClient httpClient,
+        IConfiguration configuration,
+        IHttpContextAccessor httpContextAccessor)
+        : base("EcsService", logger, httpClient, configuration, httpContextAccessor)
+    {
+    }
+
+    public async Task<bool> GetSchoolCanReviewEvidenceAsync(int laCode)
+    {
+        var url = $"local-authorities/{laCode}/settings";
+
+        var response = await ApiDataGetAsynch(url, new LocalAuthoritySettingsResponse());
+        return response?.SchoolCanReviewEvidence ?? false;
+    }
+}

--- a/CheckYourEligibility.Admin/Gateways/LocalAuthoritySettingsGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/LocalAuthoritySettingsGateway.cs
@@ -14,13 +14,12 @@ public sealed class LocalAuthoritySettingsGateway : BaseGateway, ILocalAuthority
         IHttpContextAccessor httpContextAccessor)
         : base("EcsService", logger, httpClient, configuration, httpContextAccessor)
     {
-    }
+    }    
 
-    public async Task<bool> GetSchoolCanReviewEvidenceAsync(int laCode)
+    public async Task<LocalAuthoritySettingsResponse?> GetLocalAuthoritySettingsAsync(int laCode)
     {
         var url = $"local-authorities/{laCode}/settings";
 
-        var response = await ApiDataGetAsynch(url, new LocalAuthoritySettingsResponse());
-        return response?.SchoolCanReviewEvidence ?? false;
+        return await ApiDataGetAsynch(url, new LocalAuthoritySettingsResponse());
     }
 }

--- a/CheckYourEligibility.Admin/Program.cs
+++ b/CheckYourEligibility.Admin/Program.cs
@@ -31,6 +31,7 @@ if (Environment.GetEnvironmentVariable("FSM_ADMIN_KEY_VAULT_NAME") != null)
 // Add services to the container.
 builder.Services.AddServices(builder.Configuration);
 builder.Services.AddSession();
+builder.Services.AddMemoryCache(); // ELIG-2661B: MenuProvider/HomeController cache LA settings for school dashboard tiles
 
 builder.Services.AddScoped<IAddChildUseCase, AddChildUseCase>();
 builder.Services.AddScoped<IChangeChildDetailsUseCase, ChangeChildDetailsUseCase>();

--- a/CheckYourEligibility.Admin/Program.cs
+++ b/CheckYourEligibility.Admin/Program.cs
@@ -31,7 +31,7 @@ if (Environment.GetEnvironmentVariable("FSM_ADMIN_KEY_VAULT_NAME") != null)
 // Add services to the container.
 builder.Services.AddServices(builder.Configuration);
 builder.Services.AddSession();
-builder.Services.AddMemoryCache(); // ELIG-2661B: MenuProvider/HomeController cache LA settings for school dashboard tiles
+builder.Services.AddMemoryCache(); // ELIG-2661B: cache school menu decisions per LA
 
 builder.Services.AddScoped<IAddChildUseCase, AddChildUseCase>();
 builder.Services.AddScoped<IChangeChildDetailsUseCase, ChangeChildDetailsUseCase>();

--- a/CheckYourEligibility.Admin/ProgramExtensions.cs
+++ b/CheckYourEligibility.Admin/ProgramExtensions.cs
@@ -34,7 +34,7 @@ public static class ProgramExtensions
             client.BaseAddress = new Uri(configuration["Api:Host"]);
         });
 
-        // ELIG-2661B: used to retrieve LA settings that control school dashboard tiles
+        // ELIG-2661B: used to read LA settings that control school dashboard tiles
         services.AddHttpClient<ILocalAuthoritySettingsGateway, LocalAuthoritySettingsGateway>(client =>
         {
             client.BaseAddress = new Uri(configuration["Api:Host"]);

--- a/CheckYourEligibility.Admin/ProgramExtensions.cs
+++ b/CheckYourEligibility.Admin/ProgramExtensions.cs
@@ -34,6 +34,12 @@ public static class ProgramExtensions
             client.BaseAddress = new Uri(configuration["Api:Host"]);
         });
 
+        // ELIG-2661B: used to retrieve LA settings that control school dashboard tiles
+        services.AddHttpClient<ILocalAuthoritySettingsGateway, LocalAuthoritySettingsGateway>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["Api:Host"]);
+        });
+
         services.AddScoped<IBlobStorageGateway, BlobStorageGateway>();
 
         // FSM Basic Bulk Check Services

--- a/CheckYourEligibility.Admin/ViewModels/HomeIndexViewModel.cs
+++ b/CheckYourEligibility.Admin/ViewModels/HomeIndexViewModel.cs
@@ -1,0 +1,9 @@
+﻿using CheckYourEligibility.Admin.Domain.DfeSignIn;
+
+namespace CheckYourEligibility.Admin.ViewModels;
+
+public sealed class HomeIndexViewModel
+{
+    public required DfeClaims Claims { get; init; }
+    public bool SchoolCanReviewEvidence { get; init; }
+}

--- a/CheckYourEligibility.Admin/Views/Home/Index.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Index.cshtml
@@ -1,11 +1,13 @@
 ﻿@using CheckYourEligibility.Admin.Gateways.Interfaces
 @using CheckYourEligibility.Admin.Infrastructure
+@using CheckYourEligibility.Admin.ViewModels
+@model HomeIndexViewModel
 @inject IHttpContextAccessor _httpContext
 @inject IMenuProvider MenuProvider
 
 @{
     ViewData["Title"] = "Dashboard";
-    var menu = MenuProvider.GetMenuItemsFor(ViewBag.Claims);
+    var menu = MenuProvider.GetMenuItemsFor(Model.Claims);
 }
 
 <div class="govuk-grid-column-full">
@@ -19,7 +21,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <span class="govuk-caption-l">@Model.Organisation.Name</span>
+            <span class="govuk-caption-l">@Model.Claims.Organisation.Name</span>
             <h1 class="govuk-heading-l">Manage eligibility for free school meals</h1>
         </div>
     </div>

--- a/CheckYourEligibility.Admin/Views/Home/Index.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Index.cshtml
@@ -22,8 +22,8 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <span class="govuk-caption-l">@CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Model.Organisation.Name.ToLower())</span>
-            <h1 class="govuk-heading-l">Manage eligibility for free school meals</h1>
+            <span class="govuk-caption-l">@CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Model.Claims.Organisation.Name.ToLower())</span>
+            <h1 class="govuk-heading-l">Manage eligibility for free school meals</h1> 
 
             <div class="dfe-grid-container">
                 @foreach (var item in menu)

--- a/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
@@ -74,29 +74,6 @@ describe('BasicLAHappyPath', () => {
         });
     });
 
-    it("will return an error message if more than 10 batches are attempted within an hour", () => {
-        for (let i = 0; i < 11; i++) {
-            cy.fixture("BulkCheckFileValidaiton/BASIC-bulkchecktemplate_too_many_records.csv").then(
-                (fileContent1) => {
-                    cy.get('input[type="file"]').attachFile([
-                        {
-                            fileContent: fileContent1,
-                            fileName: "BASIC-bulkchecktemplate_too_many_records.csv",
-                            mimeType: "text/csv",
-                        },
-                    ]);
-                }
-            );
-            cy.contains('button', 'Run a batch check').click();
-        }
-        cy.get("#file-upload-1-error").as("errorMessage");
-        cy.get("@errorMessage").should(($p) => {
-            expect($p.first()).to.contain(
-                "You have exceeded the maximum number of bulk upload attempts. Please try again later."
-            );
-        });
-    });
-
     it("will run a successful batch check", () => {
         cy.fixture("BulkCheckFileValidaiton/BASIC-bulkchecktemplate_complete.csv").then(
             (fileContent1) => {
@@ -133,7 +110,6 @@ describe('BasicLAHappyPath', () => {
         cy.contains('a', 'Batch checks history').click();
         cy.get('h1', { timeout: 80000 }).should('include.text', 'Batch checks history');
 
-
         cy.get('table tbody tr td:nth-child(7) a') // Get all delete links
             .filter((_, el) => /delete/i.test(el.innerText))
             .then($links => {
@@ -148,5 +124,28 @@ describe('BasicLAHappyPath', () => {
                 cy.get('h3.govuk-notification-banner__heading')
                     .should('contain.text', 'Batch check deleted successfully.');
             });
+    });
+
+    it("will return an error message if more than 10 batches are attempted within an hour", () => {
+        for (let i = 0; i < 11; i++) {
+            cy.fixture("BulkCheckFileValidaiton/BASIC-bulkchecktemplate_too_many_records.csv").then(
+                (fileContent1) => {
+                    cy.get('input[type="file"]').attachFile([
+                        {
+                            fileContent: fileContent1,
+                            fileName: "BASIC-bulkchecktemplate_too_many_records.csv",
+                            mimeType: "text/csv",
+                        },
+                    ]);
+                }
+            );
+            cy.contains('button', 'Run a batch check').click();
+        }
+        cy.get("#file-upload-1-error").as("errorMessage");
+        cy.get("@errorMessage").should(($p) => {
+            expect($p.first()).to.contain(
+                "You have exceeded the maximum number of bulk upload attempts. Please try again later."
+            );
+        });
     });
 });

--- a/tests/cypress/e2e/Admin/AdminBulkCheckJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBulkCheckJourney.spec.ts
@@ -47,6 +47,23 @@ describe('Admin Bulk Check Journey', () => {
         });
     });
 
+    it("will run a successful batch check", () => {
+        cy.fixture("BulkCheckFileValidaiton/bulkchecktemplate_complete.csv").then(
+            (fileContent1) => {
+                cy.get('input[type="file"]').attachFile([
+                    {
+                        fileContent: fileContent1,
+                        fileName: "bulkchecktemplate_complete.csv",
+                        mimeType: "text/csv",
+                    },
+                ]);
+            }
+        );
+        cy.contains('Run check').click();
+        cy.get('h1', { timeout: 80000 }).should('include.text', 'Checks completed');
+        cy.contains("Download").click();
+    });
+
     it("will return an error message if more than 10 batches are attempted within an hour", () => {
         for (let i = 0; i < 11; i++) {
             cy.fixture("BulkCheckFileValidaiton/bulkchecktemplate_too_many_records.csv").then(
@@ -68,22 +85,5 @@ describe('Admin Bulk Check Journey', () => {
                 "No more than 10 batch check requests can be made per hour"
             );
         });
-    });
-
-    it("will run a successful batch check", () => {
-        cy.fixture("BulkCheckFileValidaiton/bulkchecktemplate_complete.csv").then(
-            (fileContent1) => {
-                cy.get('input[type="file"]').attachFile([
-                    {
-                        fileContent: fileContent1,
-                        fileName: "bulkchecktemplate_complete.csv",
-                        mimeType: "text/csv",
-                    },
-                ]);
-            }
-        );
-        cy.contains('Run check').click();
-        cy.get('h1', { timeout: 80000 }).should('include.text', 'Checks completed');
-        cy.contains("Download").click();
     });
 });

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -22,7 +22,8 @@ describe('Full journey of creating an application through school portal through 
         cy.checkSession('schoolCanReviewEvidenceDisabled');
         cy.visit(Cypress.config().baseUrl ?? "");
         cy.wait(1);
-        cy.get('h1').should('include.text', 'The Astley Cooper School');
+        cy.get('.govuk-caption-l').should('include.text', 'The Astley Cooper School');
+        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
 
         cy.contains('a', 'Pending applications').should('not.exist');
         cy.contains('a', 'Finalise applications').should('not.exist');
@@ -33,7 +34,8 @@ describe('Full journey of creating an application through school portal through 
         cy.checkSession('school');
         cy.visit(Cypress.config().baseUrl ?? "");
         cy.wait(1);
-        cy.get('h1').should('include.text', 'The Telford Park School');
+        cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
+        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
 
         cy.contains('a', 'Pending applications').should('be.visible');
         cy.contains('a', 'Finalise applications').should('be.visible');

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -18,33 +18,6 @@ describe('Full journey of creating an application through school portal through 
         }
     });
 
-    it('does not show review tiles for schools whose LA has the flag disabled', () => {
-        cy.checkSession('schoolCanReviewEvidenceDisabled');
-        cy.visit(Cypress.config().baseUrl ?? "");
-        cy.wait(1);
-        cy.get('.govuk-caption-l').should('include.text', 'The Astley Cooper School');
-        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
-
-        cy.contains('a', 'Pending applications').should('not.exist');
-        cy.contains('a', 'Finalise applications').should('not.exist');
-        cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
-        });
-
-    it('shows review tiles for schools whose LA has the flag enabled', () => {
-        cy.checkSession('school');
-        cy.visit(Cypress.config().baseUrl ?? "");
-        cy.wait(1);
-        cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
-        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
-
-        cy.contains('a', 'Pending applications').should('be.visible');
-        cy.contains('a', 'Finalise applications').should('be.visible');
-        cy.contains('a', 'Guidance for reviewing evidence')
-            .should('be.visible')
-            .and('have.attr', 'href')
-            .and('include', '/Home/Guidance');
-        });
-
     it('Will allow a school user to create an application that may not be eligible and send it for appeal', () => {
         //Add parent details
         cy.contains('Run a check for one parent or guardian').click();
@@ -155,11 +128,11 @@ describe('Full journey of creating an application through school portal through 
             .invoke('text')
             .then(text => {
                 const clean = text
-                    .replace(/\u00A0/g, ' ')  
-                    .replace(/\s+/g, ' ')      
-                    .trim();                   
-        expect(clean).to.eq('nn123456c');
-        });
+                    .replace(/\u00A0/g, ' ')
+                    .replace(/\s+/g, ' ')
+                    .trim();
+                expect(clean).to.eq('nn123456c');
+            });
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Email address', parentEmailAddress);
         cy.CheckValuesInSummaryCard('Child 1 details', "Name", childFirstName + " " + childLastName);
         cy.contains('button', 'Add details').click();
@@ -182,7 +155,7 @@ describe('Full journey of creating an application through school portal through 
         cy.scanPagesForNewValue(referenceNumber);
         cy.contains('.govuk-button', 'Approve application').click();
         cy.contains('.govuk-button', 'Yes, approve now').click();
-        
+
         //Search for approved application
         cy.visit('/');
         cy.contains('Search all records').click();

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -18,6 +18,31 @@ describe('Full journey of creating an application through school portal through 
         }
     });
 
+    it('does not show review tiles for schools whose LA has the flag disabled', () => {
+        cy.checkSession('schoolCanReviewEvidenceDisabled');
+        cy.visit(Cypress.config().baseUrl ?? "");
+        cy.wait(1);
+        cy.get('h1').should('include.text', 'The Astley Cooper School');
+
+        cy.contains('a', 'Pending applications').should('not.exist');
+        cy.contains('a', 'Finalise applications').should('not.exist');
+        cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
+        });
+
+    it('shows review tiles for schools whose LA has the flag enabled', () => {
+        cy.checkSession('school');
+        cy.visit(Cypress.config().baseUrl ?? "");
+        cy.wait(1);
+        cy.get('h1').should('include.text', 'The Telford Park School');
+
+        cy.contains('a', 'Pending applications').should('be.visible');
+        cy.contains('a', 'Finalise applications').should('be.visible');
+        cy.contains('a', 'Guidance for reviewing evidence')
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', '/Home/Guidance');
+        });
+
     it('Will allow a school user to create an application that may not be eligible and send it for appeal', () => {
         //Add parent details
         cy.contains('Run a check for one parent or guardian').click();

--- a/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
@@ -1,0 +1,26 @@
+describe('Log in as schools whose LA has set that they can or cannot review evidence', () => {
+
+    it('shows review tiles for schools whose LA has the flag enabled', () => {
+        cy.checkSession('school');
+        cy.visit(Cypress.config().baseUrl ?? "");
+        cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
+        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
+        cy.contains('a', 'Pending applications').should('be.visible');
+        cy.contains('a', 'Finalise applications').should('be.visible');
+        cy.contains('a', 'Guidance for reviewing evidence')
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', '/Home/Guidance');
+    });
+
+    it('does not show review tiles for schools whose LA has the flag disabled', () => {
+        cy.checkSession('schoolCanReviewEvidenceDisabled');
+        cy.visit(Cypress.config().baseUrl ?? "");
+        cy.wait(1);
+        cy.get('.govuk-caption-l').should('include.text', 'The Astley Cooper School');
+        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
+        cy.contains('a', 'Pending applications').should('not.exist');
+        cy.contains('a', 'Finalise applications').should('not.exist');
+        cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
+    });
+});

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -15,26 +15,6 @@ function getCookiesPath(userType: string): string {
   }
 }
 
-Cypress.Commands.add('loginSchoolUserCanReviewEvidenceDisabled', () => {
-  // Log in as a school user whose LA has the review flag disabled
-  // For persisting session use checkSession('schoolCanReviewEvidenceDisabled')
-
-  cy.reload();
-  cy.visit(Cypress.config().baseUrl ?? "");
-  cy.get('#username').type(Cypress.env('DFE_ADMIN_EMAIL_ADDRESS_FLAG_OFF'));
-  cy.get('button[type="submit"]').click();
-  cy.get('#password').type(Cypress.env('DFE_ADMIN_PASSWORD_FLAG_OFF'));
-  cy.get('button[type="submit"]').click();
-  cy.reload();
-
-  cy.contains('The Astley Cooper School')
-    .parent()
-    .find('input[type="radio"]')
-    .check();
-
-  cy.contains('Continue').click();
-});
-
 Cypress.Commands.add('checkSession', (userType: string) => {
   const filePath = getCookiesPath(userType);
   cy.task<Cypress.CookieData | null>('readFileMaybe', filePath).then((data) => {
@@ -146,6 +126,25 @@ Cypress.Commands.add('loginSchoolUser', () => {
   cy.contains('Continue').click();
 });
 
+Cypress.Commands.add('loginSchoolUserCanReviewEvidenceDisabled', () => {
+  // Log in as a school user whose LA has the review flag disabled
+  // For persisting session use checkSession('schoolCanReviewEvidenceDisabled')
+  cy.reload();
+  cy.visit(Cypress.config().baseUrl ?? "");
+  cy.get('#username').type(Cypress.env('DFE_ADMIN_EMAIL_ADDRESS'));
+  cy.get('button[type="submit"]').click();
+  cy.get('#password').type(Cypress.env('DFE_ADMIN_PASSWORD'));
+  cy.get('button[type="submit"]').click();
+  cy.reload();
+
+  cy.contains('The Astley Cooper School')
+    .parent()
+    .find('input[type="radio"]')
+    .check();
+
+  cy.contains('Continue').click();
+});
+
 Cypress.Commands.add('loginLocalAuthorityUser', () => {
   // Log in as a local authority user - For persisting session use checkSession('LA')
   cy.reload(true);
@@ -198,8 +197,8 @@ Cypress.Commands.add('storeCookies', (userType: string) => {
       timestamp: Date.now(),
       cookies: cookies
     };
-    if(userType === 'basic'){}
-    else {cy.writeFile(filePath, data);}
+    if (userType === 'basic') { }
+    else { cy.writeFile(filePath, data); }
   });
 });
 

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -223,11 +223,13 @@ Cypress.Commands.add('loadCookies', (userType: string) => {
         cy.log('Cookies are older than 1 hour, forcing new login');
         if (userType === 'school') {
           cy.login('school');
+        } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+          cy.login('schoolCanReviewEvidenceDisabled');
         } else if (userType === 'MAT') {
           cy.login('MAT');
-        }else if(userType ==='Basic'){
+        } else if (userType === 'basic') {
           cy.login('basic');
-         } else {
+        } else {
           cy.login('LA');
         }
       }
@@ -235,9 +237,11 @@ Cypress.Commands.add('loadCookies', (userType: string) => {
       cy.log('Invalid cookie data, forcing new login');
       if (userType === 'school') {
         cy.login('school');
+      } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+        cy.login('schoolCanReviewEvidenceDisabled');
       } else if (userType === 'MAT') {
         cy.login('MAT');
-      } else if (userType === 'basic'){
+      } else if (userType === 'basic') {
         cy.login('basic');
       } else {
         cy.login('LA');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -49,6 +49,9 @@ Cypress.Commands.add('checkSession', (userType: string) => {
             case 'school':
               expectedText = 'The Telford Park School';
               break;
+            case 'schoolCanReviewEvidenceDisabled':
+              expectedText = 'The Astley Cooper School';
+              break;
             case 'MAT':
               expectedText = 'THOMAS TELFORD MULTI ACADEMY TRUST';
               break;
@@ -67,9 +70,11 @@ Cypress.Commands.add('checkSession', (userType: string) => {
             cy.clearCookies();
             if (userType === 'school') {
               cy.login('school');
+            } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+              cy.login('schoolCanReviewEvidenceDisabled');
             } else if (userType === 'MAT') {
               cy.login('MAT');
-            } else if (userType === 'basic'){
+            } else if (userType === 'basic') {
               cy.login('basic');
             } else {
               cy.login('LA');
@@ -80,9 +85,11 @@ Cypress.Commands.add('checkSession', (userType: string) => {
         cy.log('No cookies found, forcing new login');
         if (userType === 'school') {
           cy.login('school');
+        } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+          cy.login('schoolCanReviewEvidenceDisabled');
         } else if (userType === 'MAT') {
           cy.login('MAT');
-        } else if (userType === 'basic'){
+        } else if (userType === 'basic') {
           cy.login('basic');
         } else {
           cy.login('LA');
@@ -92,9 +99,11 @@ Cypress.Commands.add('checkSession', (userType: string) => {
       cy.log(`File not found or invalid data: ${filePath}`);
       if (userType === 'school') {
         cy.login('school');
+      } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+        cy.login('schoolCanReviewEvidenceDisabled');
       } else if (userType === 'MAT') {
         cy.login('MAT');
-      } else if (userType === 'basic'){
+      } else if (userType === 'basic') {
         cy.login('basic');
       } else {
         cy.login('LA');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -4,6 +4,8 @@ function getCookiesPath(userType: string): string {
   switch (userType) {
     case 'school':
       return 'cypress/fixtures/SchoolUserCookies.json';
+    case 'schoolCanReviewEvidenceDisabled':
+      return 'cypress/fixtures/SchoolUserFlagOffCookies.json';
     case 'MAT':
       return 'cypress/fixtures/MATUserCookies.json';
     case 'LA':
@@ -12,6 +14,26 @@ function getCookiesPath(userType: string): string {
       return '';
   }
 }
+
+Cypress.Commands.add('loginSchoolUserCanReviewEvidenceDisabled', () => {
+  // Log in as a school user whose LA has the review flag disabled
+  // For persisting session use checkSession('schoolCanReviewEvidenceDisabled')
+
+  cy.reload();
+  cy.visit(Cypress.config().baseUrl ?? "");
+  cy.get('#username').type(Cypress.env('DFE_ADMIN_EMAIL_ADDRESS_FLAG_OFF'));
+  cy.get('button[type="submit"]').click();
+  cy.get('#password').type(Cypress.env('DFE_ADMIN_PASSWORD_FLAG_OFF'));
+  cy.get('button[type="submit"]').click();
+  cy.reload();
+
+  cy.contains('The Astley Cooper School')
+    .parent()
+    .find('input[type="radio"]')
+    .check();
+
+  cy.contains('Continue').click();
+});
 
 Cypress.Commands.add('checkSession', (userType: string) => {
   const filePath = getCookiesPath(userType);

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -117,9 +117,11 @@ Cypress.Commands.add('login', (userType) => {
   cy.session([userType], () => {
     if (userType === 'school') {
       cy.loginSchoolUser();
+    } else if (userType === 'schoolCanReviewEvidenceDisabled') {
+      cy.loginSchoolUserCanReviewEvidenceDisabled();
     } else if (userType === 'MAT') {
       cy.loginMultiAcademyTrustUser();
-    } else if (userType === "basic"){
+    } else if (userType === "basic") {
       cy.loginBasicUser();
     } else {
       cy.loginLocalAuthorityUser();

--- a/tests/cypress/support/cypress.d.ts
+++ b/tests/cypress/support/cypress.d.ts
@@ -28,6 +28,7 @@ declare namespace Cypress {
     checkSession(userType: string): Chainable<void>;
     login(userType: string): Chainable<void>;
     loginSchoolUser(): Chainable<void>;
+    loginSchoolUserCanReviewEvidenceDisabled(): Chainable<void>;
     loginLocalAuthorityUser(): Chainable<void>;
     loginMultiAcademyTrustUser(): Chainable<void>;
     loginBasicUser(): Chainable<void>;


### PR DESCRIPTION
## Summary

This PR introduces support for the **Local Authority setting `SchoolCanReviewEvidence`**, allowing the visibility of school review functionality to be controlled per Local Authority.
https://dfedigital.atlassian.net/browse/ELIG-2698

## Changes

- Added support for retrieving **Local Authority settings** from the API.
- Implemented caching via the existing gateway mechanism to avoid repeated API calls.
- Updated `HomeController` to retrieve the `SchoolCanReviewEvidence` flag for the logged-in school's Local Authority.
- Updated the dashboard flow so school tile visibility is controlled through the new MenuProvider-based architecture.
- Passed the flag through the home view model to support the updated dashboard behaviour.
- Controlled visibility of:
  - **Pending applications**
  - **Finalise applications**
  - **Guidance for reviewing evidence**

## Behaviour

- Schools belonging to an LA where `SchoolCanReviewEvidence = true` will see the review tiles.
- Schools belonging to an LA where the flag is **false** will not see these tiles.

## Testing

### Unit tests
- Updated `HomeController` unit tests to reflect the new constructor dependencies and `HomeIndexViewModel` return type.
- Added coverage for school users where the LA review flag is:
  - **enabled**
  - **disabled**

### Cypress
Added Cypress tests to verify:
- Tiles are **hidden** when the LA flag is disabled.
- Tiles are **visible** when the LA flag is enabled.

## Notes

Some existing Cypress journey tests currently fail in the eligibility check flow (`Check/Enter_Details → Loader`).
These failures appear unrelated to the changes in this PR and are likely due to form validation or markup changes in the eligibility journey.