### PR TITLE
Elig 2775 fixminimatch has re do s match one combinatorial backtracking via multiple non adjacent globstar segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ FodyWeavers.xsd
 /CheckYourEligibility.Admin/CheckYourEligibility.Admin.sln
 /CheckYourEligibility.Admin.Tests/package-lock.json
 /package-lock.json
+/tests/audit.txt

--- a/CheckYourEligibility.Admin/package-lock.json
+++ b/CheckYourEligibility.Admin/package-lock.json
@@ -800,10 +800,11 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/CheckYourEligibility.Admin/package.json
+++ b/CheckYourEligibility.Admin/package.json
@@ -13,5 +13,8 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0"
+  },
+  "overrides": {
+    "minimatch": "3.1.3"
   }
 }

--- a/CheckYourEligibility.Admin/package.json
+++ b/CheckYourEligibility.Admin/package.json
@@ -15,6 +15,6 @@
     "eslint": "^8.57.0"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.4"
   }
 }


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/ELIG-2775

Confirmed this ticket applies to `CheckYourEligibility.Admin/package-lock.json`.

Dependabot identified vulnerable transitive dependency:
- `eslint 8.57.0` → `minimatch 3.1.2`

Applied npm override and uplifted to:
- `minimatch` → `3.1.4`

Validation:
- Ran `npm install`
- Verified via `npm ls minimatch` that all instances now resolve to `3.1.4`
- Re-ran `npm audit` and confirmed the minimatch vulnerability is cleared

Remaining audit findings are unrelated to minimatch and are out of scope for this ticket.