### PR TITLE
ELIG-2798   FixMissing X-Frame-Options HTTP header

### DIFF
--- a/CheckYourEligibility.Admin/Web.config
+++ b/CheckYourEligibility.Admin/Web.config
@@ -1,12 +1,13 @@
 <configuration>
-    <system.webServer>
-        <security>
-            <requestFiltering removeServerHeader="true"/>
-        </security>
-        <httpProtocol>
-            <customHeaders>
-                <remove name="X-Powered-By"/>
-            </customHeaders>
-        </httpProtocol>
-    </system.webServer>
+	<system.webServer>
+		<security>
+			<requestFiltering removeServerHeader="true"/>
+		</security>
+		<httpProtocol>
+			<customHeaders>
+				<remove name="X-Powered-By"/>
+				<add name="X-Frame-Options" value="DENY" />
+			</customHeaders>
+		</httpProtocol>
+	</system.webServer>
 </configuration>


### PR DESCRIPTION
## Investigation

CodeQL flagged a high severity vulnerability (`cs/web/missing-x-frame-options`) in `CheckYourEligibility.Admin/Web.config`.

The application configuration did not include the `X-Frame-Options` HTTP header, leaving it potentially vulnerable to clickjacking attacks via framing.

## Fix

- Updated `CheckYourEligibility.Admin/Web.config`
- Added the `X-Frame-Options` header under `system.webServer > httpProtocol > customHeaders`
- Set the value to `DENY`

## Outcome

The application now returns the `X-Frame-Options: DENY` header on all responses, mitigating clickjacking risks and resolving the CodeQL alert.

https://dfedigital.atlassian.net/browse/ELIG-2798