### PR TITLE
Elig 2945 update school can review evidence toggle rules

### DIFF
--- a/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
@@ -532,4 +532,138 @@ internal class HomeControllerTests : TestBase
         viewResult.Should().NotBeNull();
         viewResult!.ViewName.Should().Be("UnauthorizedRole");
     }
+
+    [Test]
+    public async Task Given_Index_WithValidSchoolAndRole_ReturnsHomeIndexViewModel_AndSchoolIsPartOfMatTrue()
+    {
+        // Arrange
+        var userId = "test-user-id";
+        var orgId = Guid.NewGuid();
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"urn\":\"136730\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}},\"localAuthority\":{{\"code\":\"893\"}}}}";
+
+        var claims = new List<Claim>
+    {
+        new Claim(ClaimTypes.NameIdentifier, userId),
+        new Claim(ClaimTypes.Email, "test@test.com"),
+        new Claim(ClaimTypes.GivenName, "Test"),
+        new Claim(ClaimTypes.Surname, "User"),
+        new Claim("organisation", organisationJson)
+    };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var roles = new List<Role>
+    {
+        new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "FSM - School Role",
+            Code = Constants.RoleCodeSchool,
+            NumericId = "123"
+        }
+    };
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        _mockLocalAuthoritySettingsGateway
+            .Setup(g => g.GetLocalAuthoritySettingsAsync(893))
+            .ReturnsAsync(new LocalAuthoritySettingsResponse
+            {
+                SchoolCanReviewEvidence = false
+            });
+
+        _mockAdminGateway
+            .Setup(g => g.GetMultiAcademyTrustIdForEstablishment(136730))
+            .ReturnsAsync(17101);
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.SchoolIsPartOfMat.Should().BeTrue();
+        model.SchoolCanReviewEvidence.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Given_Index_WithValidSchoolAndRole_ReturnsHomeIndexViewModel_AndSchoolIsPartOfMatFalse()
+    {
+        // Arrange
+        var userId = "test-user-id";
+        var orgId = Guid.NewGuid();
+        var organisationJson =
+            $"{{\"id\":\"{orgId}\",\"name\":\"Test School\",\"urn\":\"136730\",\"category\":{{\"id\":1,\"name\":\"{Constants.CategoryTypeSchool}\"}},\"localAuthority\":{{\"code\":\"893\"}}}}";
+
+        var claims = new List<Claim>
+    {
+        new Claim(ClaimTypes.NameIdentifier, userId),
+        new Claim(ClaimTypes.Email, "test@test.com"),
+        new Claim(ClaimTypes.GivenName, "Test"),
+        new Claim(ClaimTypes.Surname, "User"),
+        new Claim("organisation", organisationJson)
+    };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var roles = new List<Role>
+    {
+        new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "FSM - School Role",
+            Code = Constants.RoleCodeSchool,
+            NumericId = "123"
+        }
+    };
+
+        _mockDfeSignInApiService
+            .Setup(s => s.GetUserRolesAsync(userId, orgId))
+            .ReturnsAsync(roles);
+
+        _mockLocalAuthoritySettingsGateway
+            .Setup(g => g.GetLocalAuthoritySettingsAsync(893))
+            .ReturnsAsync(new LocalAuthoritySettingsResponse
+            {
+                SchoolCanReviewEvidence = false
+            });
+
+        _mockAdminGateway
+            .Setup(g => g.GetMultiAcademyTrustIdForEstablishment(136730))
+            .ReturnsAsync(0);
+
+        await _sut.GetDfeClaimsAsync();
+
+        // Act
+        var result = await _sut.Index();
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.Should().NotBeNull();
+        viewResult!.ViewName.Should().BeNull();
+        viewResult.Model.Should().BeOfType<HomeIndexViewModel>();
+
+        var model = viewResult.Model as HomeIndexViewModel;
+        model.Should().NotBeNull();
+        model!.SchoolIsPartOfMat.Should().BeFalse();
+        model.SchoolCanReviewEvidence.Should().BeFalse();
+    }
 }

--- a/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
@@ -19,6 +19,7 @@ internal class HomeControllerTests : TestBase
 {
     private Mock<IDfeSignInApiService> _mockDfeSignInApiService;
     private Mock<ILocalAuthoritySettingsGateway> _mockLocalAuthoritySettingsGateway;
+    private Mock<IAdminGateway> _mockAdminGateway;
     private IMemoryCache _memoryCache;
     private HomeController _sut;
 
@@ -27,11 +28,13 @@ internal class HomeControllerTests : TestBase
     {
         _mockDfeSignInApiService = new Mock<IDfeSignInApiService>();
         _mockLocalAuthoritySettingsGateway = new Mock<ILocalAuthoritySettingsGateway>();
+        _mockAdminGateway = new Mock<IAdminGateway>();
         _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
         _sut = new HomeController(
             _mockDfeSignInApiService.Object,
             _mockLocalAuthoritySettingsGateway.Object,
+            _mockAdminGateway.Object,
             _memoryCache);
 
         base.SetUp();
@@ -53,6 +56,7 @@ internal class HomeControllerTests : TestBase
         var controller = new HomeController(
             _mockDfeSignInApiService.Object,
             _mockLocalAuthoritySettingsGateway.Object,
+            _mockAdminGateway.Object,
             new MemoryCache(new MemoryCacheOptions()));
 
         // Act
@@ -72,6 +76,7 @@ internal class HomeControllerTests : TestBase
         var controller = new HomeController(
             _mockDfeSignInApiService.Object,
             _mockLocalAuthoritySettingsGateway.Object,
+            _mockAdminGateway.Object,
             new MemoryCache(new MemoryCacheOptions()));
 
         // Act

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -142,9 +142,9 @@ public class HomeController : BaseController
             return false;
         }
 
-        var establishmentNumberString = _Claims?.Organisation?.EstablishmentNumber;
+        var establishmentIdString = _Claims?.Organisation?.Urn;
 
-        if (!int.TryParse(establishmentNumberString, out var establishmentId))
+        if (!int.TryParse(establishmentIdString, out var establishmentId))
         {
             return false;
         }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -11,6 +11,7 @@ namespace CheckYourEligibility.Admin.Controllers;
 public class HomeController : BaseController
 {
     private readonly ILocalAuthoritySettingsGateway _localAuthoritySettingsGateway;
+    private readonly IApplicationGateway _applicationGateway;
     private readonly IMemoryCache _cache;
 
     public HomeController(
@@ -56,11 +57,13 @@ public class HomeController : BaseController
         }
 
         var schoolCanReviewEvidence = await CacheAndGetSchoolCanReviewEvidence();
+        var schoolIsPartOfMat = await GetSchoolIsPartOfMat();        
 
         var model = new HomeIndexViewModel
         {
             Claims = _Claims,
-            SchoolCanReviewEvidence = schoolCanReviewEvidence
+            SchoolCanReviewEvidence = schoolCanReviewEvidence,
+            SchoolIsPartOfMat = schoolIsPartOfMat
         };
 
         return View(model);
@@ -125,5 +128,38 @@ public class HomeController : BaseController
         }
 
         return localAuthoritySettings?.SchoolCanReviewEvidence ?? false;
+    }
+
+    private async Task<bool> CacheAndGetSchoolIsPartOfMat()
+    {
+        var isSchoolUser = _Claims?.Roles?.Any(r =>
+            string.Equals(r.Code, Constants.RoleCodeSchool, StringComparison.OrdinalIgnoreCase)) == true;
+
+        if (!isSchoolUser)
+        {
+            return false;
+        }
+
+        var establishmentNumberString = _Claims?.Organisation?.EstablishmentNumber;
+
+        if (!int.TryParse(establishmentNumberString, out var establishmentId))
+        {
+            return false;
+        }
+
+        var cacheKey = $"SchoolMatMembership_{establishmentId}";
+
+        if (_cache.TryGetValue(cacheKey, out bool cachedIsPartOfMat))
+        {
+            return cachedIsPartOfMat;
+        }
+
+        var matId = await _yourAdminGateway.GetMultiAcademyTrustIdForEstablishmentAsync(establishmentId);
+
+        var schoolIsPartOfMat = matId > 0;
+
+        _cache.Set(cacheKey, schoolIsPartOfMat, TimeSpan.FromMinutes(5));
+
+        return schoolIsPartOfMat;
     }
 }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -11,15 +11,17 @@ namespace CheckYourEligibility.Admin.Controllers;
 public class HomeController : BaseController
 {
     private readonly ILocalAuthoritySettingsGateway _localAuthoritySettingsGateway;
-    private readonly IApplicationGateway _applicationGateway;
+    private readonly IAdminGateway _adminGateway;
     private readonly IMemoryCache _cache;
 
     public HomeController(
-        IDfeSignInApiService dfeSignInApiService,
-        ILocalAuthoritySettingsGateway localAuthoritySettingsGateway,
-        IMemoryCache cache) : base(dfeSignInApiService)
+    IDfeSignInApiService dfeSignInApiService,
+    ILocalAuthoritySettingsGateway localAuthoritySettingsGateway,
+    IAdminGateway adminGateway,
+    IMemoryCache cache) : base(dfeSignInApiService)
     {
         _localAuthoritySettingsGateway = localAuthoritySettingsGateway;
+        _adminGateway = adminGateway;
         _cache = cache;
     }
 
@@ -57,7 +59,7 @@ public class HomeController : BaseController
         }
 
         var schoolCanReviewEvidence = await CacheAndGetSchoolCanReviewEvidence();
-        var schoolIsPartOfMat = await GetSchoolIsPartOfMat();        
+        var schoolIsPartOfMat = await CacheAndGetSchoolIsPartOfMat();
 
         var model = new HomeIndexViewModel
         {
@@ -154,7 +156,7 @@ public class HomeController : BaseController
             return cachedIsPartOfMat;
         }
 
-        var matId = await _yourAdminGateway.GetMultiAcademyTrustIdForEstablishmentAsync(establishmentId);
+        var matId = await _adminGateway.GetMultiAcademyTrustIdForEstablishment(establishmentId);
 
         var schoolIsPartOfMat = matId > 0;
 

--- a/CheckYourEligibility.Admin/Gateways/AdminGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/AdminGateway.cs
@@ -92,4 +92,22 @@ public class AdminGateway : BaseGateway, IAdminGateway
             throw;
         }
     }
+
+    public async Task<int> GetMultiAcademyTrustIdForEstablishment(int establishmentId)
+    {
+        try
+        {
+            var response = await ApiDataGetAsynch(
+                $"{_httpClient.BaseAddress?.OriginalString}/establishment/{establishmentId}/multi-academy-trust-id",
+                0);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                $"Get failed. uri-{_httpClient.BaseAddress}/establishment/{establishmentId}/multi-academy-trust-id");
+            throw;
+        }
+    }
 }

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IAdminGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IAdminGateway.cs
@@ -10,4 +10,5 @@ public interface IAdminGateway
     Task<ApplicationSearchResponse> PostApplicationSearch(ApplicationRequestSearch requestBody);
     Task<ApplicationStatusUpdateResponse> PatchApplicationStatus(string id, ApplicationStatus status);
     Task<ApplicationStatusRestoreResponse> RestoreApplicationStatus(string id);
+    Task<int> GetMultiAcademyTrustIdForEstablishment(int establishmentId);
 }

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -24,11 +24,11 @@ public class MenuProvider : IMenuProvider
 
         var role = claims.Roles[0].Code;
 
-        // ELIG-2661B: school menus depend on LA settings, so include LA code in the cache key
         var laCode = claims.Organisation?.LocalAuthority?.Code ?? "none";
+        var establishmentId = claims.Organisation?.EstablishmentNumber ?? "none";
 
         var cacheKey = role == "fsmSchoolRole"
-            ? $"Menu_{role}_{laCode}"
+            ? $"Menu_{role}_{laCode}_{establishmentId}"
             : $"Menu_{role}";
 
         return _cache.GetOrCreate(cacheKey, entry =>

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -25,7 +25,7 @@ public class MenuProvider : IMenuProvider
         var role = claims.Roles[0].Code;
 
         var laCode = claims.Organisation?.LocalAuthority?.Code ?? "none";
-        var establishmentId = claims.Organisation?.EstablishmentNumber ?? "none";
+        var establishmentId = claims.Organisation?.Urn ?? "none";
 
         var cacheKey = role == "fsmSchoolRole"
             ? $"Menu_{role}_{laCode}_{establishmentId}"
@@ -104,7 +104,7 @@ public class MenuProvider : IMenuProvider
                 if (!string.IsNullOrWhiteSpace(establishmentId) &&
                     int.TryParse(establishmentId, out var parsedEstablishmentId))
                 {
-                    _cache.TryGetValue($"SchoolMatMembership_{parsedEstablishmentId}", out schoolIsPartOfMat);
+                    var foundInCache = _cache.TryGetValue($"SchoolMatMembership_{parsedEstablishmentId}", out schoolIsPartOfMat);
                 }
 
                 var schoolCanReviewEvidence = localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -32,19 +32,17 @@ public class MenuProvider : IMenuProvider
             : $"Menu_{role}";
 
         return _cache.GetOrCreate(cacheKey, entry =>
-        {
-            // ELIG-2661B: keep this short so school tiles reflect LA setting changes reasonably quickly
+        {            
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
 
-            return BuildMenuForRole(role, laCode);
+            return BuildMenuForRole(role, laCode, establishmentId);
         }) ?? Array.Empty<MenuItem>();
     }
 
-    private IEnumerable<MenuItem> BuildMenuForRole(string role, string? laCode)
+    private IEnumerable<MenuItem> BuildMenuForRole(string role, string? laCode, string? establishmentId)
     {
         LocalAuthoritySettingsResponse? localAuthoritySettingsResponse = null;
 
-        // ELIG-2661B: Jenna moved menu construction here, so read the LA setting from cache at menu-build time
         if (!string.IsNullOrWhiteSpace(laCode))
         {
             _cache.TryGetValue($"LocalAuthoritySettings_{laCode}", out localAuthoritySettingsResponse);
@@ -100,7 +98,17 @@ public class MenuProvider : IMenuProvider
                 };
 
             case "fsmSchoolRole":
+
+                var schoolIsPartOfMat = false;
+
+                if (!string.IsNullOrWhiteSpace(establishmentId) &&
+                    int.TryParse(establishmentId, out var parsedEstablishmentId))
+                {
+                    _cache.TryGetValue($"SchoolMatMembership_{parsedEstablishmentId}", out schoolIsPartOfMat);
+                }
+
                 var schoolCanReviewEvidence = localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
+                var showReviewEvidenceTiles = schoolIsPartOfMat || schoolCanReviewEvidence;
 
                 var schoolMenuItems = new List<MenuItem>
     {
@@ -127,7 +135,7 @@ public class MenuProvider : IMenuProvider
         )
     };
 
-                if (schoolCanReviewEvidence)
+                if (showReviewEvidenceTiles)
                 {
                     schoolMenuItems.Add(
                         new MenuItem(
@@ -166,7 +174,7 @@ public class MenuProvider : IMenuProvider
                         "FSMFormDownload"
                     ));
 
-                if (schoolCanReviewEvidence)
+                if (showReviewEvidenceTiles)
                 {
                     schoolMenuItems.Add(
                         new MenuItem(

--- a/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckYourEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -100,33 +100,32 @@ public class MenuProvider : IMenuProvider
                 };
 
             case "fsmSchoolRole":
-                // ELIG-2661B: school review/finalise/guidance tiles are controlled by the LA setting
                 var schoolCanReviewEvidence = localAuthoritySettingsResponse?.SchoolCanReviewEvidence ?? false;
 
                 var schoolMenuItems = new List<MenuItem>
-                {
-                    new MenuItem(
-                        "Home",
-                        "Home",
-                        "Dashboard",
-                        "Home",
-                        ""
-                        ),
-                    new MenuItem(
-                        "Run a check",
-                        "Run a check for one parent or guardian",
-                        "Run an eligibility check for one parent or guardian.",
-                        "Check",
-                        "Consent_Declaration"
-                    ),
-                    new MenuItem(
-                        "Run batch check",
-                        "Run a batch check",
-                        "Run an eligibility check for multiple parents or guardians.",
-                        "BulkCheck",
-                        "Bulk_Check"
-                    )
-                };
+    {
+        new MenuItem(
+            "Home",
+            "Home",
+            "Dashboard",
+            "Home",
+            ""
+        ),
+        new MenuItem(
+            "Run a check",
+            "Run a check for one parent or guardian",
+            "Run an eligibility check for one parent or guardian.",
+            "Check",
+            "Consent_Declaration"
+        ),
+        new MenuItem(
+            "Run batch check",
+            "Run a batch check",
+            "Run an eligibility check for multiple parents or guardians.",
+            "BulkCheck",
+            "Bulk_Check"
+        )
+    };
 
                 if (schoolCanReviewEvidence)
                 {
@@ -138,16 +137,16 @@ public class MenuProvider : IMenuProvider
                             "Application",
                             "PendingApplications"
                         ));
-
-                    schoolMenuItems.Add(
-                        new MenuItem(
-                            "Finalise applications",
-                            "Finalise applications",
-                            "Finalise applications.",
-                            "Application",
-                            "FinaliseApplications"
-                        ));
                 }
+
+                schoolMenuItems.Add(
+                    new MenuItem(
+                        "Finalise applications",
+                        "Finalise applications",
+                        "Finalise applications.",
+                        "Application",
+                        "FinaliseApplications"
+                    ));
 
                 schoolMenuItems.Add(
                     new MenuItem(

--- a/CheckYourEligibility.Admin/ViewModels/HomeIndexViewModel.cs
+++ b/CheckYourEligibility.Admin/ViewModels/HomeIndexViewModel.cs
@@ -6,4 +6,5 @@ public sealed class HomeIndexViewModel
 {
     public required DfeClaims Claims { get; init; }
     public bool SchoolCanReviewEvidence { get; init; }
+    public bool SchoolIsPartOfMat { get; init; }
 }

--- a/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
@@ -6,21 +6,19 @@ describe('Log in as schools whose LA has set that they can or cannot review evid
         cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
         cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
         cy.contains('a', 'Pending applications').should('be.visible');
-        cy.contains('a', 'Finalise applications').should('be.visible');
         cy.contains('a', 'Guidance for reviewing evidence')
             .should('be.visible')
             .and('have.attr', 'href')
             .and('include', '/Home/Guidance');
     });
 
-    it('does not show review tiles for schools whose LA has the flag disabled', () => {
+    it('does not show review tiles for non-MAT schools whose LA flag is disabled', () => {
         cy.checkSession('schoolCanReviewEvidenceDisabled');
         cy.visit((Cypress.config().baseUrl ?? "") + "/home");
         cy.wait(1);
         cy.get('.govuk-caption-l').should('include.text', 'The Astley Cooper School');
         cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
         cy.contains('a', 'Pending applications').should('not.exist');
-        cy.contains('a', 'Finalise applications').should('not.exist');
         cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
     });
 });


### PR DESCRIPTION
Implements AC2: dashboard tile visibility logic for schools.

- Added MAT membership support via new API endpoint
- Cached MAT membership in HomeController
- Extended HomeIndexViewModel with SchoolIsPartOfMat
- Updated MenuProvider to combine:
  SchoolIsPartOfMat || SchoolCanReviewEvidence

Adds unit tests for MAT membership logic and updates existing tests.

Result:
- MAT schools always see Pending Applications and Guidance tiles
- Non-MAT schools depend on LA setting

Manual testing completed across MAT and non-MAT scenarios.