### PR TITLE
Elig 2867 fsm ensure each page has a unique title

### DIFF
--- a/CheckYourEligibility.Admin/Views/BulkCheck/Bulk_Loader.cshtml
+++ b/CheckYourEligibility.Admin/Views/BulkCheck/Bulk_Loader.cshtml
@@ -2,6 +2,10 @@
     ViewData["Title"] = "Checking";
 }
 
+@section Head {
+    <meta http-equiv="refresh" content="0; url='@Url.Action("Bulk_Loader", "BulkCheck")'" />
+}
+
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckYourEligibility.Admin/Views/Check/Loader.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Loader.cshtml
@@ -2,6 +2,10 @@
     ViewData["Title"] = "Checking their Eligibility";
 }
 
+@section Head {
+    <meta http-equiv="refresh" content="0; url='@Url.Action("Loader", "Check")'" />
+}
+
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckYourEligibility.Admin/Views/Check/Loader_Basic.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Loader_Basic.cshtml
@@ -2,6 +2,10 @@
     ViewData["Title"] = "Checking their Eligibility";
 }
 
+@section Head {
+    <meta http-equiv="refresh" content="0; url='@Url.Action("Loader_Basic", "Check")'" />
+}
+
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckYourEligibility.Admin/Views/Check/Report/Report_Loader.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/Report_Loader.cshtml
@@ -2,6 +2,11 @@
     ViewData["Title"] = "Generating your report";
 }
 
+
+@section Head {
+    <meta http-equiv="refresh" content="0;url=/Check/Report_Loader" />
+}
+
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckYourEligibility.Admin/Views/Check/Report/Report_Loader.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/Report_Loader.cshtml
@@ -2,9 +2,8 @@
     ViewData["Title"] = "Generating your report";
 }
 
-
 @section Head {
-    <meta http-equiv="refresh" content="0;url=/Check/Report_Loader" />
+    <meta http-equiv="refresh" content="0; url='@Url.Action("Report_Loader", "Check")'" />
 }
 
 <div class="govuk-grid-column-full">

--- a/CheckYourEligibility.Admin/Views/Check/Report/Report_Results.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/Report_Results.cshtml
@@ -2,15 +2,18 @@
 @using Newtonsoft.Json
 @model CheckYourEligibility.Admin.Boundary.Responses.EligibilityCheckReportResponse
 @{
-    ViewData["Title"] = $"Report generated on {ViewBag.ReportGeneratedDate}";
+    ViewData["Title"] = "Report generated";
 }
+
 <div class="govuk-grid-column-full">
+    <a class="govuk-back-link-nolink"></a>
+
     <div id="content" data-type="Results" class="govuk-grid-row">
         <div class="govuk-grid-column-full">
 
             <div class="moj-page-header-actions">
                 <div class="moj-page-header-actions__title">
-                    <h1 class="govuk-heading-l">Report generated on @ViewBag.ReportGeneratedDate</h1>
+                    <h1 class="govuk-heading-l">@ViewData["Title"] on @ViewBag.ReportGeneratedDate</h1>
                     <p class="govuk-body"><a class="govuk-link" href="@Url.Action("Reports", "Check")">View all reports</a></p>
 
                 </div>

--- a/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
@@ -29,6 +29,7 @@
     <link href="~/css/application.css" rel="stylesheet" />
     <link href="~/css/govuk-frontend-6.0.0.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    @RenderSection("Head", required: false)
 </head>
 
 <body class="govuk-template__body js-enabled" data-clarity="@clarityId">

--- a/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
 <html lang="en" class="govuk-template">
 <head>
     <meta charset="utf-8">
-    <title>@ViewData["Title"] - Manage eligibility for free school meals - Department for Education</title>
+    <title>@ViewData["Title"] - Manage eligibility for free school meals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
- Update Layout title to remove 'Department for Education' from the tab title.
- Report_Results tab title now shows when the page loads after generating rather than retaining the loader tab title.
- Added no-back-link spacer on Report_Results page to fix layout inconsistency.

[https://dfedigital.atlassian.net/browse/ELIG-2867](https://dfedigital.atlassian.net/browse/ELIG-2867)