### PR TITLE
ELIG-2873-Remove unneccessary image alt text

### DIFF
--- a/CheckYourEligibility.Admin/Views/Home/FSMFormDownload.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/FSMFormDownload.cshtml
@@ -16,7 +16,7 @@
     <section>
         <div class="govuk-grid-column-one-quarter fsm-image">
             <a target="_blank" tabindex="-1" aria-hidden="true" href="~/documents/offline-fsm-form.pdf">
-                <img alt="thumbnail image of free school meals form" src="~/images/fsm-form-thumbnail.png">
+                <img alt="" src="~/images/fsm-form-thumbnail.png">
             </a>
         </div>
         <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
Remove unnecessary image alt text.

[https://dfedigital.atlassian.net/browse/ELIG-2873](https://dfedigital.atlassian.net/browse/ELIG-2873)