### PR TITLE
ELIG-2878-FSM-ADMIN-Missing landmark structure prevents screen reader users from finding important information

### DIFF
--- a/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.Admin/Views/Shared/_Layout.cshtml
@@ -100,7 +100,7 @@
 
     @await Html.PartialAsync("_HeaderMenu")
 
-    <div class="govuk-phase-banner govuk-width-container">
+    <div class="govuk-phase-banner govuk-width-container" role="complementary">
         <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">
                 beta


### PR DESCRIPTION
Add complimentary label to beta banner.

[https://dfedigital.atlassian.net/browse/ELIG-2878](https://dfedigital.atlassian.net/browse/ELIG-2878)