### PR TITLE
ELIG-2879-FSMAdmin-Ensure-screen-reader-users-can-distinguish-between-page-sections-by-giving-each-landmark-a-unique-name

### DIFF
--- a/CheckYourEligibility.Admin/Views/Check/Report/Create_Report.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/Create_Report.cshtml
@@ -6,11 +6,11 @@
 
     <a class="govuk-back-link backLinkJS" href="@Url.Action("Index", "Home")">Back</a>
 
-    <main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
 
-                <h1 class="govuk-heading-l">Generate a report</h1>
+                <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
                 <p>Generate a report showing the checks carried out using this service and the outcome of each check.</p>
                 <p>Select a date range for the report:</p>
 
@@ -22,7 +22,6 @@
                 }
 
                 <form asp-action="Create_Report" method="post">
-
                     <!-- START DATE -->
                     <div class="govuk-form-group @(ViewData.ModelState["StartDate"]?.Errors.Count > 0 ? "govuk-form-group--error" : "")">
                         <fieldset class="govuk-fieldset">
@@ -58,7 +57,6 @@
                                            id="StartDate.Year"
                                            class="govuk-input govuk-date-input__input govuk-input--width-4 @(ViewData.ModelState["StartDate.Year"]?.Errors.Count > 0 ? "govuk-input--error" : "")" />
                                 </div>
-
                             </div>
                         </fieldset>
                     </div>
@@ -98,15 +96,13 @@
                                            id="EndDate.Year"
                                            class="govuk-input govuk-date-input__input govuk-input--width-4 @(ViewData.ModelState["EndDate.Year"]?.Errors.Count > 0 ? "govuk-input--error" : "")" />
                                 </div>
-
                             </div>
                         </fieldset>
                     </div>
 
                     <button class="govuk-button">Generate report</button>
                 </form>
-
             </div>
         </div>
-    </main>
+    </div>
 </div>

--- a/CheckYourEligibility.Admin/Views/Check/Report/report-history.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/report-history.cshtml
@@ -1,21 +1,21 @@
 @model CheckYourEligibility.Admin.Boundary.Responses.EligibilityCheckReportHistoryResponse
+
 @{
     ViewData["Title"] = "Report history";
 }
+
 <div class="govuk-width-container">
-
     <a class="govuk-back-link backLinkJS" href="@Url.Action("Index", "Home")">Back</a>
-  <main class="govuk-main-wrapper" id="main-content">
 
+    <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-
-                <h1 class="govuk-heading-l">Report history</h1>
+                <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
                 <a class="govuk-button" href="@Url.Action("Create_Report", "Check")">Generate report</a>
-             
+
                 <table class="govuk-table govuk-table--small-text-until-tablet">
                     <caption class="govuk-table__caption govuk-table__caption--s govuk-!-margin-bottom-4">
-                            Showing @Model.Data.Count() reports generated in the last 7 days
+                        Showing @Model.Data.Count() reports generated in the last 7 days
                     </caption>
 
                     <thead class="govuk-table__head">
@@ -38,25 +38,18 @@
                                 <td class="govuk-table__cell">@item.EndDate.ToString("d MMM yyyy")</td>
                                 <td class="govuk-table__cell">@item.GeneratedBy</td>
                                 <td class="govuk-table__cell">@item.NumberOfResults</td>
-
                                 <td class="govuk-table__cell">
-                                <a class="govuk-link"
-                                    aria-label="View report generated on @item.ReportGeneratedDate.ToString("dd MMMM yyyy")"
-                                    href="@Url.Action("View_Historical_Report", "Check",
-                                        new { startDate = item.StartDate.ToString("yyyy-MM-dd"),
-                                              endDate = item.EndDate.ToString("yyyy-MM-dd"),
-                                              generated = item.ReportGeneratedDate.ToString("yyyy-MM-dd") 
-                                        })">
-                                     View report
-                                 </a>
-                            </td>
+                                    <a class="govuk-link"
+                                       aria-label="View report generated on @item.ReportGeneratedDate.ToString("dd MMMM yyyy")"
+                                       href="@Url.Action("View_Historical_Report", "Check", new { startDate = item.StartDate.ToString("yyyy-MM-dd"), endDate = item.EndDate.ToString("yyyy-MM-dd"), generated = item.ReportGeneratedDate.ToString("yyyy-MM-dd") })">
+                                        View report
+                                    </a>
+                                </td>
                             </tr>
                         }
                     </tbody>
                 </table>
-
             </div>
         </div>
-
-    </main>
+    </div>
 </div>


### PR DESCRIPTION
- Ensure only one 'main'  landmark exists per page.
- Refactor page formatting to re-enable VS autoformatting.

[https://dfedigital.atlassian.net/browse/ELIG-2879](https://dfedigital.atlassian.net/browse/ELIG-2879)