### PR TITLE
Elig 2983 update cypress tests for fsm school can review evidence feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,3 +414,4 @@ FodyWeavers.xsd
 /CheckYourEligibility.Admin.Tests/package-lock.json
 /package-lock.json
 /tests/audit.txt
+/tests/cypress/screenshots/AdminReviewEvidenceVisibility.spec.ts

--- a/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
@@ -1,4 +1,4 @@
-describe('Log in as schools whose LA has set that they can or cannot review evidence', () => {
+describe('SchoolCanReviewEvidence dashboard tile visibility', () => {
 
     it('shows review tiles for schools whose LA has the flag enabled', () => {
         cy.checkSession('school');
@@ -16,9 +16,23 @@ describe('Log in as schools whose LA has set that they can or cannot review evid
         cy.checkSession('schoolCanReviewEvidenceDisabled');
         cy.visit((Cypress.config().baseUrl ?? "") + "/home");
         cy.wait(1);
-        cy.get('.govuk-caption-l').should('include.text', 'The Astley Cooper School');
+        cy.get('.govuk-caption-l').should('include.text', 'The Aldgate School');
         cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
         cy.contains('a', 'Pending applications').should('not.exist');
         cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
+    });
+
+    it('shows review tiles for schools in a MAT even when the LA flag is disabled', () => {
+        cy.checkSession('matSchoolWithLaFlagDisabled');
+        cy.visit((Cypress.config().baseUrl ?? "") + "/home");
+
+        cy.get('.govuk-caption-l').should('include.text', 'Thomas Telford Multi Academy Trust');
+        cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
+
+        cy.contains('a', 'Pending applications').should('be.visible');
+        cy.contains('a', 'Guidance for reviewing evidence')
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', '/Home/Guidance');
     });
 });

--- a/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
@@ -15,20 +15,18 @@ describe('SchoolCanReviewEvidence dashboard tile visibility', () => {
     it('does not show review tiles for non-MAT schools whose LA flag is disabled', () => {
         cy.checkSession('schoolCanReviewEvidenceDisabled');
         cy.visit((Cypress.config().baseUrl ?? "") + "/home");
-        cy.wait(1);
         cy.get('.govuk-caption-l').should('include.text', 'The Aldgate School');
         cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
         cy.contains('a', 'Pending applications').should('not.exist');
         cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
     });
 
-    it('shows review tiles for schools in a MAT even when the LA flag is disabled', () => {
+    it('shows review tiles for MAT-linked schools even when the LA flag is disabled', () => {
         cy.checkSession('matSchoolWithLaFlagDisabled');
         cy.visit((Cypress.config().baseUrl ?? "") + "/home");
 
-        cy.get('.govuk-caption-l').should('include.text', 'Thomas Telford Multi Academy Trust');
+        cy.get('.govuk-caption-l').should('include.text', 'Altrincham Grammar School For Girls');
         cy.get('h1').should('include.text', 'Manage eligibility for free school meals');
-
         cy.contains('a', 'Pending applications').should('be.visible');
         cy.contains('a', 'Guidance for reviewing evidence')
             .should('be.visible')

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -6,6 +6,8 @@ function getCookiesPath(userType: string): string {
       return 'cypress/fixtures/SchoolUserCookies.json';
     case 'schoolCanReviewEvidenceDisabled':
       return 'cypress/fixtures/SchoolUserFlagOffCookies.json';
+    case 'matSchoolWithLaFlagDisabled':
+      return 'cypress/fixtures/MatSchoolFlagOffCookies.json';
     case 'MAT':
       return 'cypress/fixtures/MATUserCookies.json';
     case 'LA':
@@ -30,7 +32,10 @@ Cypress.Commands.add('checkSession', (userType: string) => {
               expectedText = 'The Telford Park School';
               break;
             case 'schoolCanReviewEvidenceDisabled':
-              expectedText = 'The Astley Cooper School';
+               expectedText = 'The Aldgate School';
+              break;
+            case 'matSchoolWithLaFlagDisabled':
+              expectedText = 'Thomas Telford Multi Academy Trust';
               break;
             case 'MAT':
               expectedText = 'Thomas Telford Multi Academy Trust';
@@ -52,6 +57,8 @@ Cypress.Commands.add('checkSession', (userType: string) => {
               cy.login('school');
             } else if (userType === 'schoolCanReviewEvidenceDisabled') {
               cy.login('schoolCanReviewEvidenceDisabled');
+            } else if (userType === 'matSchoolWithLaFlagDisabled') {
+              cy.login('matSchoolWithLaFlagDisabled');
             } else if (userType === 'MAT') {
               cy.login('MAT');
             } else if (userType === 'basic') {
@@ -67,6 +74,8 @@ Cypress.Commands.add('checkSession', (userType: string) => {
           cy.login('school');
         } else if (userType === 'schoolCanReviewEvidenceDisabled') {
           cy.login('schoolCanReviewEvidenceDisabled');
+        } else if (userType === 'matSchoolWithLaFlagDisabled') {
+          cy.login('matSchoolWithLaFlagDisabled');
         } else if (userType === 'MAT') {
           cy.login('MAT');
         } else if (userType === 'basic') {
@@ -81,6 +90,8 @@ Cypress.Commands.add('checkSession', (userType: string) => {
         cy.login('school');
       } else if (userType === 'schoolCanReviewEvidenceDisabled') {
         cy.login('schoolCanReviewEvidenceDisabled');
+      } else if (userType === 'matSchoolWithLaFlagDisabled') {
+        cy.login('matSchoolWithLaFlagDisabled');
       } else if (userType === 'MAT') {
         cy.login('MAT');
       } else if (userType === 'basic') {
@@ -99,6 +110,8 @@ Cypress.Commands.add('login', (userType) => {
       cy.loginSchoolUser();
     } else if (userType === 'schoolCanReviewEvidenceDisabled') {
       cy.loginSchoolUserCanReviewEvidenceDisabled();
+    } else if (userType === 'matSchoolWithLaFlagDisabled') {
+      cy.loginMultiAcademyTrustUser();
     } else if (userType === 'MAT') {
       cy.loginMultiAcademyTrustUser();
     } else if (userType === "basic") {
@@ -137,7 +150,7 @@ Cypress.Commands.add('loginSchoolUserCanReviewEvidenceDisabled', () => {
   cy.get('button[type="submit"]').click();
   cy.reload();
 
-  cy.contains('The Astley Cooper School')
+  cy.contains('The Aldgate School')
     .parent()
     .find('input[type="radio"]')
     .check();
@@ -224,6 +237,8 @@ Cypress.Commands.add('loadCookies', (userType: string) => {
           cy.login('school');
         } else if (userType === 'schoolCanReviewEvidenceDisabled') {
           cy.login('schoolCanReviewEvidenceDisabled');
+        } else if (userType === 'matSchoolWithLaFlagDisabled') {
+          cy.login('matSchoolWithLaFlagDisabled');
         } else if (userType === 'MAT') {
           cy.login('MAT');
         } else if (userType === 'basic') {
@@ -238,6 +253,8 @@ Cypress.Commands.add('loadCookies', (userType: string) => {
         cy.login('school');
       } else if (userType === 'schoolCanReviewEvidenceDisabled') {
         cy.login('schoolCanReviewEvidenceDisabled');
+      } else if (userType === 'matSchoolWithLaFlagDisabled') {
+        cy.login('matSchoolWithLaFlagDisabled');
       } else if (userType === 'MAT') {
         cy.login('MAT');
       } else if (userType === 'basic') {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -35,7 +35,7 @@ Cypress.Commands.add('checkSession', (userType: string) => {
                expectedText = 'The Aldgate School';
               break;
             case 'matSchoolWithLaFlagDisabled':
-              expectedText = 'Thomas Telford Multi Academy Trust';
+              expectedText = 'Altrincham Grammar School For Girls';
               break;
             case 'MAT':
               expectedText = 'Thomas Telford Multi Academy Trust';
@@ -111,7 +111,7 @@ Cypress.Commands.add('login', (userType) => {
     } else if (userType === 'schoolCanReviewEvidenceDisabled') {
       cy.loginSchoolUserCanReviewEvidenceDisabled();
     } else if (userType === 'matSchoolWithLaFlagDisabled') {
-      cy.loginMultiAcademyTrustUser();
+      cy.loginMatSchoolWithLaFlagDisabled();
     } else if (userType === 'MAT') {
       cy.loginMultiAcademyTrustUser();
     } else if (userType === "basic") {
@@ -151,6 +151,23 @@ Cypress.Commands.add('loginSchoolUserCanReviewEvidenceDisabled', () => {
   cy.reload();
 
   cy.contains('The Aldgate School')
+    .parent()
+    .find('input[type="radio"]')
+    .check();
+
+  cy.contains('Continue').click();
+});
+
+Cypress.Commands.add('loginMatSchoolWithLaFlagDisabled', () => {
+  cy.reload(true);
+  cy.visit((Cypress.config().baseUrl ?? "") + "/home");
+  cy.get('#username').type(Cypress.env('DFE_ADMIN_EMAIL_ADDRESS'));
+  cy.get('button[type="submit"]').click();
+  cy.get('#password').type(Cypress.env('DFE_ADMIN_PASSWORD'));
+  cy.get('button[type="submit"]').click();
+  cy.reload();
+
+  cy.contains('Altrincham Grammar School for Girls (Open)')
     .parent()
     .find('input[type="radio"]')
     .check();

--- a/tests/cypress/support/cypress.d.ts
+++ b/tests/cypress/support/cypress.d.ts
@@ -29,6 +29,7 @@ declare namespace Cypress {
     login(userType: string): Chainable<void>;
     loginSchoolUser(): Chainable<void>;
     loginSchoolUserCanReviewEvidenceDisabled(): Chainable<void>;
+    loginMatSchoolWithLaFlagDisabled(): Chainable<void>;
     loginLocalAuthorityUser(): Chainable<void>;
     loginMultiAcademyTrustUser(): Chainable<void>;
     loginBasicUser(): Chainable<void>;


### PR DESCRIPTION
### Summary

Updates Cypress coverage for SchoolCanReviewEvidence to reflect correct business scenarios, including MAT override behaviour.

### Changes

- Updated flag-disabled school scenario to use The Aldgate School
- Replaced MAT organisation test with MAT-linked school (Altrincham Grammar School For Girls)
- Added new Cypress command to support MAT-linked school login
- Updated session and cookie handling
- Fixed organisation selection by using exact login-page labels

### Behaviour covered

- School with LA flag enabled → tiles visible
- Non-MAT school with LA flag disabled → tiles hidden
- MAT-linked school with LA flag disabled → tiles visible (override)

### Testing

- Cypress tests pass locally
- Manual verification completed for all scenarios