### PR TITLE
ELIG-3042 Parent National Insurance Number must be Parent National Insurance number to be consistent with the normal FSM template and cypress tests

### DIFF
--- a/CheckYourEligibility.Admin/Usecases/ParseBulkCheckFileUseCase_FsmBasic.cs
+++ b/CheckYourEligibility.Admin/Usecases/ParseBulkCheckFileUseCase_FsmBasic.cs
@@ -44,7 +44,7 @@ namespace CheckYourEligibility.Admin.Usecases
 
         public async Task<BulkCheckCsvResultFsmBasic> Execute(Stream csvStream)
         {
-            string[] expectedHeaders = { "Parent First Name", "Parent Last Name", "Parent Date of Birth", "Parent National Insurance Number"};
+            string[] expectedHeaders = { "Parent First Name", "Parent Last Name", "Parent Date of Birth", "Parent National Insurance number"};
 
             var result = new BulkCheckCsvResultFsmBasic();
 

--- a/CheckYourEligibility.Admin/wwwroot/documents/BulkCheckTemplate_FSMB.csv
+++ b/CheckYourEligibility.Admin/wwwroot/documents/BulkCheckTemplate_FSMB.csv
@@ -1,1 +1,1 @@
-Parent First Name,Parent Last Name,Parent Date of Birth,Parent National Insurance Number
+Parent First Name,Parent Last Name,Parent Date of Birth,Parent National Insurance number


### PR DESCRIPTION
Parent National Insurance Number must be Parent National Insurance number to be consistent with the normal FSM template and cypress tests