### PR TITLE
ELIG-3050 FSM-Admin accessibility fixed missed in second round

### DIFF
--- a/CheckYourEligibility.Admin/Views/Application/EditorTemplates/SelectPersonEditorViewModel.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/EditorTemplates/SelectPersonEditorViewModel.cshtml
@@ -28,7 +28,7 @@
     @if (Model.ShowSelectorCheck)
     {
         <td class="govuk-checkboxes__item moj-multi-select__checkbox centerer">
-            @Html.CheckBoxFor(model => model.Selected)
+            @Html.CheckBoxFor(model => model.Selected, new { aria_label = "select " + Model.Person.Reference })
         </td>
     }
     else

--- a/CheckYourEligibility.Admin/Views/Application/FinaliseApplications.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/FinaliseApplications.cshtml
@@ -17,8 +17,10 @@
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <p class="govuk-body">All the children in the table on this page are entitled to free school meals. Now
-                    you should finalise their applications.</p>
+                <p class="govuk-body">
+                    All the children in the table on this page are entitled to free school meals. Now
+                    you should finalise their applications.
+                </p>
             </div>
         </div>
     </div>
@@ -36,6 +38,7 @@
         <div class="govuk-grid-column-full @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-form-group--error")">
             @if (!string.IsNullOrEmpty(errorMessage))
             {
+                ViewData["Title"] = "Error: " + errorMessage;
                 <p id="file-upload-1-error" class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span> @errorMessage
                 </p>
@@ -46,22 +49,22 @@
 
                     <input type="submit" name="operation" id="submit" value="Finalise applications"
                            class="govuk-button  @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-file-upload--error")"
-                           data-module="govuk-button"/>
+                           data-module="govuk-button" />
 
                     @Html.ActionLink("Download all files", "FinalisedApplicationsdownload", "Application", null, new { @class = "govuk-button govuk-button--secondary" })
                 </div>
 
-                <table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
+                <table class="govuk-table">
                     <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th class="govuk-table__header" scope="col" id="select-all"></th>
-                        <th class="govuk-table__header" scope="col">Reference</th>
-                        <th class="govuk-table__header" scope="col">Parent / Guardian</th>
-                        <th class="govuk-table__header" scope="col">Child</th>
-                        <th class="govuk-table__header" scope="col">Child date of birth</th>
-                        <th class="govuk-table__header" scope="col"> Status</th>
-                        <th class="govuk-table__header" scope="col">Submission date</th>
-                    </tr>
+                        <tr class="govuk-table__row">
+                            <th class="govuk-table__header" scope="col" id="select-all" aria-label="Select records"></th>
+                            <th class="govuk-table__header" scope="col">Reference</th>
+                            <th class="govuk-table__header" scope="col">Parent / Guardian</th>
+                            <th class="govuk-table__header" scope="col">Child</th>
+                            <th class="govuk-table__header" scope="col">Child date of birth</th>
+                            <th class="govuk-table__header" scope="col"> Status</th>
+                            <th class="govuk-table__header" scope="col">Submission date</th>
+                        </tr>
                     </thead>
 
                     @Html.EditorFor(model => model.People)

--- a/CheckYourEligibility.Admin/Views/Application/SearchResults.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/SearchResults.cshtml
@@ -189,7 +189,7 @@
                                                            name="DateRange.DateFrom" type="radio"
                                                            value="@firstDayOfCurrentMonth"
                                                            @(selectedDateFrom == firstDayOfCurrentMonth ? "checked" : "")>
-                                                    <label class="govuk-label govuk-radios__label" for="date range">
+                                                    <label class="govuk-label govuk-radios__label" for="DateRangeNow">
                                                         Current month to date
                                                     </label>
                                                 </div>
@@ -198,7 +198,7 @@
                                                            name="DateRange.DateFrom" type="radio"
                                                            value="@formattedThreeMonthsAgo"
                                                            @(selectedDateFrom == formattedThreeMonthsAgo ? "checked" : "")>
-                                                    <label class="govuk-label govuk-radios__label" for="date range-2">
+                                                    <label class="govuk-label govuk-radios__label" for="DateRange-3">
                                                         Last 3 months
                                                     </label>
                                                 </div>
@@ -207,7 +207,7 @@
                                                            name="DateRange.DateFrom" type="radio"
                                                            value="@formattedSixMonthsAgo"
                                                            @(selectedDateFrom == formattedSixMonthsAgo ? "checked" : "")>
-                                                    <label class="govuk-label govuk-radios__label" for="date range-3">
+                                                    <label class="govuk-label govuk-radios__label" for="DateRange-6">
                                                         Last 6 months
                                                     </label>
                                                 </div>
@@ -216,7 +216,7 @@
                                                            name="DateRange.DateFrom" type="radio"
                                                            value="@formattedTwelveMonthsAgo"
                                                            @(selectedDateFrom == formattedTwelveMonthsAgo ? "checked" : "")>
-                                                    <label class="govuk-label govuk-radios__label" for="date range-3">
+                                                    <label class="govuk-label govuk-radios__label" for="DateRange-12">
                                                         Last 12 months
                                                     </label>
                                                 </div>


### PR DESCRIPTION
- SearchResults filter radio button labels linked to their corresponding inputs.
- Finalise records - Screen reader table header description “Select records” added for selection column. Checkboxes now have aria-labels stating reference for disambiguation.

https://dfedigital.atlassian.net/browse/ELIG-3050