### PR TITLE
Elig 2888 fsm mvp remove references to carrying out separate checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,4 @@ FodyWeavers.xsd
 /package-lock.json
 /tests/audit.txt
 /tests/cypress/screenshots/AdminReviewEvidenceVisibility.spec.ts
+/tests/run-cypress.ps1

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible.cshtml
@@ -35,11 +35,7 @@
             @Html.ActionLink("Appeal now", "Enter_Child_Details", "Check", null, new { @class = "govuk-button" })
 
             <p class="govuk-body">
-                Alternatively, you can
-                <a href="@Configuration["ContactUsUrl"]" class="govuk-link">
-                    contact the Department for Education support desk
-                </a>
-                to request a separate check
+                You can contact the relevant school to ask them to collect it from the parent or guardian.
             </p>
 
             <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
@@ -42,31 +42,18 @@
             </p>
 
             <h2 class="govuk-heading-m">If you have not received any evidence</h2>
-            <p class="govuk-body">You can either contact:</p>
+
             @if (orgType == OrganisationCategory.LocalAuthority)
             {
-                <ul class="govuk-list govuk-list--bullet">
-                    <li> the relevant school to ask them to collect it from the parent or guardian</li>
-                    <li>
-                        the<a href="@Configuration["ContactUsUrl"]" class="govuk-link">
-                            Department for Education support
-                            desk
-                        </a>to request a separate check
-                    </li>
-                </ul>
+                <p class="govuk-body">
+                    You can contact the relevant school to ask them to collect it from the parent or guardian.
+                </p>
             }
             else if (orgType == OrganisationCategory.MultiAcademyTrust)
-
             {
-                <ul class="govuk-list govuk-list--bullet">
-                    <li> the relevant academy to ask them to collect it from the parent or guardian</li>
-                    <li>
-                        the<a href="@Configuration["ContactUsUrl"]" class="govuk-link">
-                            Department for Education support
-                            desk
-                        </a>to request a separate check
-                    </li>
-                </ul>
+                <p class="govuk-body">
+                    You can contact the relevant academy to ask them to collect it from the parent or guardian.
+                </p>
             }
 
             <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
@@ -4,8 +4,6 @@
     var orgType = TempData["organisationType"] as OrganisationCategory?;
 }
 
-@inject IConfiguration Configuration
-
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
@@ -197,11 +197,7 @@
                         relevant section)
                     </li>
                     <li>their annual gross income is no more than £16,190</li>
-                </ul>
-                <p>
-                    Alternatively, you can contact the DfE support desk on <a href="">ecs.admin@education.gov.uk</a> to arrange
-                    a separate check.
-                </p>
+                </ul>                
                 <p>
                     You can also <a target="_blank" href="https://assets.publishing.service.gov.uk/media/63d92829d3bf7f251e968cdb/Free_school_meals.pdf">
                         read
@@ -227,11 +223,7 @@
                 <p>
                     If either of these forms show that Working Tax Credit run-on is in payment, then they are entitled to claim
                     free school meals for their children.
-                </p>
-                <p>
-                    Alternatively, you can contact the DfE support desk on <a href="">ecs.admin@education.gov.uk</a> to arrange
-                    a separate check.
-                </p>
+                </p>               
                 <p>
                     You can also <a target="_blank" href="https://assets.publishing.service.gov.uk/media/63d92829d3bf7f251e968cdb/Free_school_meals.pdf">
                         read

--- a/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
@@ -95,15 +95,19 @@ describe('BasicLAHappyPath', () => {
             year: 'numeric'
         }).replace(',', ''); // e.g. "16 Feb 2026"
 
-        cy.get('table tbody tr').first().within(() => {
-            cy.get('td').eq(0).should('have.text', 'BASIC-bulkchecktemplate_complete.csv');
-            cy.get('td').eq(1).should('have.text', '15');
-            cy.get('td').eq(2).should('have.text', 'Tester');
-            cy.get('td').eq(3).should('contain.text', today);
-            cy.get('td').eq(4).invoke('text').then(t => t.trim()).should('not.be.empty');
-            cy.get('td').eq(5).find('strong').should('have.class', 'govuk-tag');
-            cy.get('td').eq(6).should('contain.text', 'Delete');
-        });
+        cy.contains('table tbody tr', 'BASIC-bulkchecktemplate_complete.csv', { timeout: 80000 })
+            .should('exist')
+            .within(() => {
+                cy.get('td').eq(0).invoke('text').then((text) => {
+                    expect(text.trim()).to.match(/\.csv$/i);
+                });
+                cy.get('td').eq(1).should('have.text', '15');
+                cy.get('td').eq(2).should('have.text', 'Tester');
+                cy.get('td').eq(3).should('contain.text', today);
+                cy.get('td').eq(4).invoke('text').then(t => t.trim()).should('not.be.empty');
+                cy.get('td').eq(5).find('strong').should('have.class', 'govuk-tag');
+                cy.get('td').eq(6).should('contain.text', 'Delete');
+            });
     });
 
     it("Navigate to Batch checks history and delete a batch check if one exists", () => {

--- a/tests/cypress/e2e/Admin/AdminBasicJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBasicJourney.spec.ts
@@ -34,6 +34,32 @@ describe('BasicLAHappyPath', () => {
         cy.get('h2.govuk-notification-banner__title', { timeout: 80000 }).should('include.text', 'Children eligible');
         cy.contains('a.govuk-button', 'Do another check');
     });
+
+    it('Will show updated guidance when a basic user check is not eligible', () => {
+        cy.contains('Run a check for one parent or guardian').click();
+        cy.url().should('include', '/Check/Enter_Details_Basic');
+    
+        cy.get('#FirstName').type(parentFirstName);
+        cy.get('#LastName').type(parentLastName);
+        cy.get('[id="DateOfBirth.Day"]').type('01');
+        cy.get('[id="DateOfBirth.Month"]').type('01');
+        cy.get('[id="DateOfBirth.Year"]').type('1990');
+        cy.get('#NationalInsuranceNumber').type('PN123456A');
+    
+        cy.contains('button', 'Perform check').click();
+    
+        cy.url().should('include', 'Check/Loader');
+    
+        cy.get('h2.govuk-notification-banner__title', { timeout: 80000 })
+            .should('include.text', 'May not be eligible');
+    
+        cy.contains('You can contact the relevant school to ask them to collect it from the parent or guardian.')
+            .should('be.visible');
+    
+        cy.contains('request a separate check').should('not.exist');
+        cy.contains('Department for Education support desk').should('not.exist');
+    });
+    
     it('Will allow a basic user to generate a report for the last week', () => {
         cy.contains('a.dfe-card-link--header', 'Reports').click();
         cy.get('.govuk-heading-l').should('include.text', 'Report history');

--- a/tests/cypress/e2e/Admin/AdminBasicJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBasicJourney.spec.ts
@@ -36,25 +36,33 @@ describe('BasicLAHappyPath', () => {
     });
 
     it('Will show updated guidance when a basic user check is not eligible', () => {
+        cy.checkSession('basic');
+    
+        cy.visit((Cypress.config().baseUrl ?? "") + "/home");
+        cy.get('.govuk-caption-l').should('include.text', 'Manchester City Council');
+    
         cy.contains('Run a check for one parent or guardian').click();
+    
         cy.url().should('include', '/Check/Enter_Details_Basic');
     
-        cy.get('#FirstName').type(parentFirstName);
-        cy.get('#LastName').type(parentLastName);
-        cy.get('[id="DateOfBirth.Day"]').type('01');
-        cy.get('[id="DateOfBirth.Month"]').type('01');
-        cy.get('[id="DateOfBirth.Year"]').type('1990');
-        cy.get('#NationalInsuranceNumber').type('PN123456A');
+        cy.get('#FirstName').clear().type(parentFirstName);
+        cy.get('#LastName').clear().type(parentLastName);
+        cy.get('[id="DateOfBirth.Day"]').clear().type('01');
+        cy.get('[id="DateOfBirth.Month"]').clear().type('01');
+        cy.get('[id="DateOfBirth.Year"]').clear().type('1990');
+        cy.get('#NationalInsuranceNumber').clear().type('PN123456A');
     
         cy.contains('button', 'Perform check').click();
     
-        cy.url().should('include', 'Check/Loader');
+        cy.url({ timeout: 80000 }).should('include', '/Check/Loader');
     
         cy.get('h2.govuk-notification-banner__title', { timeout: 80000 })
-            .should('include.text', 'May not be eligible');
+            .should('contain.text', 'May not be eligible');
     
-        cy.contains('You can contact the relevant school to ask them to collect it from the parent or guardian.')
-            .should('be.visible');
+        cy.contains(
+            'You can contact the relevant school to ask them to collect it from the parent or guardian.',
+            { timeout: 80000 }
+        ).should('be.visible');
     
         cy.contains('request a separate check').should('not.exist');
         cy.contains('Department for Education support desk').should('not.exist');

--- a/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
@@ -36,7 +36,7 @@ const visitPrefilledForm = (onlyfill?: boolean) => {
 
 describe("Links on not eligible page route to the intended locations", () => {
     beforeEach(() => {
-        cy.checkSession('school'); // if no session exists login as given type
+        cy.checkSession('school');
         visitPrefilledForm();
         cy.contains('Perform check').click();
     });
@@ -49,12 +49,9 @@ describe("Links on not eligible page route to the intended locations", () => {
         });
     });
 
-    it("Support link should route to DfE form", () => {
-        cy.contains('a.govuk-link', 'contact the Department for Education support desk', { timeout: 8000 }).then(($link) => {
-            const url = $link.prop('href');
-            cy.visit(url);
-            cy.get('a.govuk-service-navigation__link').should('contain.text', "Customer Help Portal");
-        });
+    it("Not eligible page should not show separate check support desk content", () => {
+        cy.contains('contact the Department for Education support desk').should('not.exist');
+        cy.contains('request a separate check').should('not.exist');
     });
 });
 

--- a/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
@@ -36,7 +36,7 @@ const visitPrefilledForm = (onlyfill?: boolean) => {
 
 describe("Links on not eligible page route to the intended locations", () => {
     beforeEach(() => {
-        cy.checkSession('school');
+        cy.checkSession('schoolNonMatFlagOn');
         visitPrefilledForm();
         cy.contains('Perform check').click();
     });

--- a/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
+++ b/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
@@ -167,22 +167,28 @@ describe('Keyword search validation', () => {
 
   it('Returns date filtered results when a radio is selected and filter can be removed', () => {
     cy.contains('Search all records').click();
+  
     cy.get("#DateRangeNow").click();
     cy.contains(".govuk-button", "Apply filters").click();
-    cy.wait(100);
-    cy.contains('td.govuk-table__cell', 'No results found.').should('not.exist');
-    cy.contains(".moj-filter__tag", "Current month to date").click();
-    cy.contains(".moj-filter__tag").should('not.exist');
+  
+    cy.contains(".moj-filter__tag", "Current month to date", { timeout: 8000 })
+      .should('be.visible')
+      .click();
+  
+    cy.contains(".moj-filter__tag", "Current month to date").should('not.exist');
   });
 
   it('Returns status filtered results when a Status is selected and filter can be removed', () => {
     cy.contains('Search all records').click();
+  
     cy.get("#Status_ReviewedEntitled").click();
     cy.contains(".govuk-button", "Apply filters").click();
-    cy.wait(100);
-    cy.contains('td.govuk-table__cell', 'No results found.').should('not.exist');
-    cy.contains(".moj-filter__tag", "Reviewed entitled").click();
-    cy.contains(".moj-filter__tag").should('not.exist');
+  
+    cy.contains(".moj-filter__tag", "Reviewed entitled", { timeout: 8000 })
+      .should('be.visible')
+      .click();
+  
+    cy.contains(".moj-filter__tag", "Reviewed entitled").should('not.exist');
   });
 
   it('Returns the record when First and Last name of Parent are searched', () => {


### PR DESCRIPTION
### Changes

- Updated PN not eligible flow content to direct users to relevant school
- Removed obsolete separate check wording from:
-- Child Tax Credit guidance
-- Working Tax Credit run on guidance

### Testing

- Verified PN NINO flow displays updated wording
- Verified Child Tax Credit guidance no longer shows obsolete paragraph
- Verified Working Tax Credit run on guidance no longer shows obsolete paragraph