### PR TITLE
ELIG-3032: Add X-Robots-Tag support to disable search indexing

### DIFF
--- a/CheckYourEligibility.Admin/Program.cs
+++ b/CheckYourEligibility.Admin/Program.cs
@@ -98,6 +98,10 @@ app.Use((context, next) =>
     context.Response.Headers["Cache-Control"] = "Private";
     context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
     context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    if (!builder.Configuration.GetValue<bool>("AllowSearchIndexing"))
+    {
+        context.Response.Headers["X-Robots-Tag"] = "none";
+    }
     return next.Invoke();
 });
 app.UseSession();

--- a/CheckYourEligibility.Admin/appsettings.json
+++ b/CheckYourEligibility.Admin/appsettings.json
@@ -14,6 +14,7 @@
     }
   },
   "AllowedHosts": "*",
+  "AllowSearchIndexing": false,
   "Api": {
     "Host": "",
     "AuthorisationUsername": "",
@@ -46,7 +47,7 @@
     "CookieExpireTimeSpanInMinutes": 5,
     "GetClaimsFromUserInfoEndpoint": true,
     "SaveTokens": true,
-    "SlidingExpiration": true,  
+    "SlidingExpiration": true,
     "ContactUsUrl": "https://help.signin.education.gov.uk/contact-us"
   },
   "AccessibilityStatementUrl": "https://accessibility-statements.education.gov.uk/s/71",


### PR DESCRIPTION
Added X-Robots-Tag to response headers when app setting "AllowSearchIndexing" = "false"