### PR TITLE
Elig 3069 schools and schools tied to academies can navigate directly to application pending applications and home guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,4 @@ FodyWeavers.xsd
 /package-lock.json
 /tests/audit.txt
 /tests/cypress/screenshots/AdminReviewEvidenceVisibility.spec.ts
+/tests/run-cypress.ps1

--- a/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
@@ -632,7 +632,7 @@ public class ApplicationController : BaseController
         var context = await _schoolMenuContextResolver.ResolveAsync(_Claims);
 
         if (context.IsSchool && !context.ShowReviewEvidenceTiles)
-            return View("UnauthorizedRole");
+            return View("~/Views/Home/UnauthorizedRole.cshtml");
 
         OrganisationCategory organisationType = _Claims.Organisation.Category.Id;
         TempData["organisationType"] = organisationType;

--- a/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
@@ -1,11 +1,10 @@
 // Ignore Spelling: Finalise
 
-using System.Globalization;
-using System.Text;
 using CheckYourEligibility.Admin.Boundary.Requests;
 using CheckYourEligibility.Admin.Boundary.Responses;
 using CheckYourEligibility.Admin.Domain.DfeSignIn;
 using CheckYourEligibility.Admin.Domain.Enums;
+using CheckYourEligibility.Admin.Gateways;
 using CheckYourEligibility.Admin.Gateways.Interfaces;
 using CheckYourEligibility.Admin.Infrastructure;
 using CheckYourEligibility.Admin.Models;
@@ -14,6 +13,8 @@ using CheckYourEligibility.Admin.ViewModels;
 using CsvHelper;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using System.Globalization;
+using System.Text;
 
 //using CheckYourEligibility.Admin.Gateways.Domain;
 
@@ -628,15 +629,21 @@ public class ApplicationController : BaseController
 
     public async Task<IActionResult> PendingApplications(int PageNumber)
     {
+        var context = await _schoolMenuContextResolver.ResolveAsync(_Claims);
+
+        if (context.IsSchool && !context.ShowReviewEvidenceTiles)
+            return View("UnauthorizedRole");
+
         OrganisationCategory organisationType = _Claims.Organisation.Category.Id;
         TempData["organisationType"] = organisationType;
 
         var applicationSearch = GetApplicationsForStatuses(
             new List<ApplicationStatus>
             {
-                ApplicationStatus.SentForReview
+            ApplicationStatus.SentForReview
             },
             PageNumber, 10);
+
         return await GetResults(applicationSearch, "ApplicationDetailLa", false, true, true);
     }
 

--- a/CheckYourEligibility.Admin/Controllers/BaseController.cs
+++ b/CheckYourEligibility.Admin/Controllers/BaseController.cs
@@ -13,7 +13,7 @@ public class BaseController : Controller
 	protected DfeClaims? _Claims;
 
 	private readonly IDfeSignInApiService _dfeSignInApiService;
-    private readonly ISchoolMenuContextResolver _schoolMenuContextResolver;
+    protected readonly ISchoolMenuContextResolver _schoolMenuContextResolver;
 
     public BaseController(
     IDfeSignInApiService dfeSignInApiService,

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -79,7 +79,15 @@ public class HomeController : BaseController
 
     public IActionResult Cookies() => View("Cookies");
 
-    public IActionResult Guidance() => View("Guidance");
+    public async Task<IActionResult> Guidance()
+    {
+        var context = await _schoolMenuContextResolver.ResolveAsync(_Claims);
+
+        if (context.IsSchool && !context.ShowReviewEvidenceTiles)
+            return View("UnauthorizedRole");
+
+        return View("Guidance");
+    }
 
     public IActionResult Guidance_Redirect()
     {

--- a/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
@@ -36,7 +36,7 @@ const visitPrefilledForm = (onlyfill?: boolean) => {
 
 describe("Links on not eligible page route to the intended locations", () => {
     beforeEach(() => {
-        cy.checkSession('school'); // if no session exists login as given type
+        cy.checkSession('schoolNonMatFlagOn');
         visitPrefilledForm();
         cy.contains('Perform check').click();
     });

--- a/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminReviewEvidenceVisibility.spec.ts
@@ -44,4 +44,18 @@ describe('SchoolCanReviewEvidence dashboard tile visibility', () => {
         cy.contains('a', 'Pending applications').should('not.exist');
         cy.contains('a', 'Guidance for reviewing evidence').should('not.exist');
     });
+
+    it('redirects to unauthorized role page when disabled school navigates directly to Pending Applications', () => {
+        cy.checkSession('schoolCanReviewEvidenceDisabled');
+        cy.visit((Cypress.config().baseUrl ?? "") + '/Application/PendingApplications');
+    
+        cy.contains('You do not have access to this service').should('be.visible');
+    });
+
+    it('redirects to unauthorized role page when disabled school navigates directly to Guidance', () => {
+        cy.checkSession('schoolCanReviewEvidenceDisabled');
+        cy.visit((Cypress.config().baseUrl ?? "") + '/Home/Guidance');
+    
+        cy.contains('You do not have access to this service').should('be.visible');
+    });
 });


### PR DESCRIPTION
Added server-side guards for direct navigation to review-evidence routes when school/MAT flags are disabled.
Extended Cypress coverage to verify blocked access to:

```

- /Application/PendingApplications
- /Home/Guidance

```