### PR TITLE
ELIG-2242 Update pagination design on 'Pending Applications' Table

### DIFF
--- a/CheckYourEligibility.Admin/Views/Application/PendingApplications.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/PendingApplications.cshtml
@@ -100,7 +100,10 @@
                     ControllerName = "PendingApplications"
                 };
 
-                @Html.Partial("PaginationPartial", paginationModel)
+                @if (paginationModel.TotalPages > 1)
+                {
+                    <partial name="PaginationPartial" model="paginationModel" />
+                }
             }
         </div>
     </div>


### PR DESCRIPTION
## Summary

Updated Pending Applications pagination behaviour to align with revised AC and GDS guidance.

Pagination is now only rendered when there is more than one page of results (`TotalPages > 1`).

## Changes

* Wrapped `PaginationPartial` rendering in a conditional check
* Prevented pagination controls from displaying for 10 or fewer records
* Retained existing pagination behaviour for 11+ records

## Testing

Verified:

* 0 records → no pagination displayed
* 1–10 records → no pagination displayed
* 11+ records → pagination displayed correctly with 10 records per page
