### PR TITLE
ELIG-3168 Content change

### DIFF
--- a/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
@@ -28,7 +28,7 @@
                     date it was sent.
                 </p>
                 <p>Their latest statement should refer to the month immediately before the date of their request.</p>
-                <p>They are entitled to targeted free school meals if:  </p>
+                <p>They are entitled to targeted free school meals if:</p>
                 <ul class="govuk-list--bullet">
                     <li>
                         the take-home pay in their latest Universal Credit statement is <strong>

--- a/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Evidence_Guidance.cshtml
@@ -21,16 +21,14 @@
             <div id="accordion-default-content-1" class="govuk-accordion__section-content"
                  aria-labelledby="accordion-default-heading-1">
                 <p class="govuk-body">
-                    To see if a parent or guardian can claim free school meals for their children, you
-                    must find their <strong>take-home pay</strong> in the Universal Credit statements they’ve
-                    provided.
+                    If the parent or guardian provides Universal Credit statements, they are entitled to free school meals.
                 </p>
                 <p>
                     <strong>Important:</strong> Any statements provided must show the parent/guardian’s income and the
                     date it was sent.
                 </p>
                 <p>Their latest statement should refer to the month immediately before the date of their request.</p>
-                <p>They are entitled if: </p>
+                <p>They are entitled to targeted free school meals if:  </p>
                 <ul class="govuk-list--bullet">
                     <li>
                         the take-home pay in their latest Universal Credit statement is <strong>


### PR DESCRIPTION
In the Universal Credit statements section of: [Reviewing supporting evidence - Manage eligibility for free school meals](https://test.check-free-school-meals-admin.education.gov.uk/Home/EvidenceGuidance)

Replace the text:
To see if a parent or guardian can claim free school meals for their children, you must find their take-home pay in the Universal Credit statements they’ve provided.

With
If the parent or guardian provides Universal Credit statements, they are entitled to free school meals.

Replace the bullet list lead-in line
They are entitled if:

With
They are entitled to targeted free school meals if:

https://dfedigital.atlassian.net/browse/ELIG-3168