### PR TITLE
Elig 3018 front end user can view fsm tier value when reporting on data

### DIFF
--- a/CheckYourEligibility.Admin/Controllers/EligibilityCheckReportingController.cs
+++ b/CheckYourEligibility.Admin/Controllers/EligibilityCheckReportingController.cs
@@ -269,7 +269,8 @@ public class EligibilityCheckReportingController : BaseController
                     DateCheckSubmitted = x.DateCheckSubmitted.ToString("d MMMM yyyy"),
                     CheckType = x.ProcessingType,
                     CheckedBy = x.CheckedBy,
-                    Outcome = x.OutcomeDisplay
+                    Outcome = x.OutcomeDisplay,
+                    Tier = x.Tier
                 }).ToList();
 
                 csv.WriteRecords(exportData);

--- a/CheckYourEligibility.Admin/Models/EligibilityCheckReportCsvExport.cs
+++ b/CheckYourEligibility.Admin/Models/EligibilityCheckReportCsvExport.cs
@@ -24,4 +24,7 @@ public class EligibilityCheckReportCsvExport
 
     [Name("Outcome")]
     public string Outcome { get; set; }
+
+    [Name("Tier")]
+    public string Tier { get; set; }
 }


### PR DESCRIPTION
Updated report CSV download to include the Tier column.

The report export now includes the eligibility tier value supplied by the API:
- Eligible targeted
- Eligible expanded
- N/A

No changes were made to report generation logic or filtering behaviour.