### PR TITLE
Elig 3317 front end remove lower limit age range validation for child date of birth fsm only

### DIFF
--- a/CheckYourEligibility.Admin/Attributes/DobAttribute.cs
+++ b/CheckYourEligibility.Admin/Attributes/DobAttribute.cs
@@ -168,11 +168,11 @@ public class DobAttribute : ValidationAttribute
                     var academicYearStart = new DateTime(currentAcademicYear, 9, 1);
                     var ageOnAcademicYearStart = CalculateAge(dob, academicYearStart);
 
-                    if (ageOnAcademicYearStart < 4 || ageOnAcademicYearStart > 19)
+                    if (ageOnAcademicYearStart >= 19)
                     {
                         TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
                         return new ValidationResult(
-                            $"{ti.ToTitleCase(_objectName)} {childIndex} must have been aged between 4 and 19 at the beginning of the academic year to be eligible",
+                            $"{ti.ToTitleCase(_objectName)} {childIndex} must be under the age of 19 at the beginning of the academic year to be eligible",
                             new[] { "DateOfBirth", "Day", "Month", "Year" });
                     }
                 }

--- a/CheckYourEligibility.Admin/Attributes/DobAttribute.cs
+++ b/CheckYourEligibility.Admin/Attributes/DobAttribute.cs
@@ -10,18 +10,20 @@ public class DobAttribute : ValidationAttribute
     private readonly string _dayPropertyName;
     private readonly string _fieldName;
     private readonly bool _isRequired;
+    private readonly bool _applyMinimumAge;
     private readonly string _monthPropertyName;
     private readonly string _objectName;
     private readonly string _yearPropertyName;
 
     public DobAttribute(string fieldName, string objectName, string? childIndexPropertyName, string dayPropertyName,
         string monthPropertyName, string yearPropertyName, bool isRequired = true, bool applyAgeRange = false,
-        string? errorMessage = null) : base(errorMessage)
+        bool applyMinimumAge = true, string? errorMessage = null) : base(errorMessage)
     {
         _fieldName = fieldName;
         _objectName = objectName;
         _isRequired = isRequired;
         _applyAgeRange = applyAgeRange;
+        _applyMinimumAge = applyMinimumAge;
         _childIndexPropertyName = childIndexPropertyName;
         _dayPropertyName = dayPropertyName;
         _monthPropertyName = monthPropertyName;
@@ -168,11 +170,19 @@ public class DobAttribute : ValidationAttribute
                     var academicYearStart = new DateTime(currentAcademicYear, 9, 1);
                     var ageOnAcademicYearStart = CalculateAge(dob, academicYearStart);
 
-                    if (ageOnAcademicYearStart >= 19)
+                    var belowMinimumAge = _applyMinimumAge && ageOnAcademicYearStart < 4;
+                    var aboveMaximumAge = ageOnAcademicYearStart >= 19;
+
+                    if (belowMinimumAge || aboveMaximumAge)
                     {
                         TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
+
+                        message = aboveMaximumAge
+                            ? $"{ti.ToTitleCase(_objectName)} {childIndex} must be under the age of 19 at the beginning of the academic year to be eligible"
+                            : $"{ti.ToTitleCase(_objectName)} {childIndex} must have been aged between 4 and 19 at the beginning of the academic year to be eligible";
+
                         return new ValidationResult(
-                            $"{ti.ToTitleCase(_objectName)} {childIndex} must be under the age of 19 at the beginning of the academic year to be eligible",
+                            message,
                             new[] { "DateOfBirth", "Day", "Month", "Year" });
                     }
                 }

--- a/CheckYourEligibility.Admin/Models/Child.cs
+++ b/CheckYourEligibility.Admin/Models/Child.cs
@@ -14,7 +14,7 @@ public class Child
     public string? LastName { get; set; }
 
     [NotMapped]
-    [Dob("date of birth", "child", "ChildIndex", "Day", "Month", "Year", true, true)]
+    [Dob("date of birth", "child", "ChildIndex", "Day", "Month", "Year", true, true, false)]
     public string? DateOfBirth { get; set; }
 
     public string? Day { get; set; }

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -38,8 +38,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.contains('button', 'Add another child').click();
         cy.contains('button', 'Remove').click();
@@ -184,8 +184,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.contains('button', 'Save and continue').click();
 
@@ -211,5 +211,58 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Check/ApplicationsRegistered');
     });  
 
-   
+    it('Will prevent a child aged 19 at the beginning of the academic year from continuing', () => {
+
+        cy.checkSession('school');
+        cy.visit((Cypress.config().baseUrl ?? "") + "/home");
+        cy.wait(1);
+        cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
+    
+        // Add parent details
+        cy.contains('Run a check for one parent or guardian').click();
+        cy.get('#consent').check();
+        cy.get('#submitButton').click();
+    
+        cy.url().should('include', '/Check/Enter_Details');
+    
+        cy.get('#FirstName').type(parentFirstName);
+        cy.get('#LastName').type(parentLastName);
+        cy.get('#EmailAddress').type(parentEmailAddress);
+    
+        cy.get('[id="DateOfBirth.Day"]').type('01');
+        cy.get('[id="DateOfBirth.Month"]').type('01');
+        cy.get('[id="DateOfBirth.Year"]').type('1990');
+    
+        cy.get('#NationalInsuranceNumber').type("nn123456c");
+    
+        cy.contains('button', 'Perform check').click();
+    
+        // Loader page
+        cy.url().should('include', 'Check/Loader');
+    
+        // Eligible outcome page
+        cy.get('.govuk-notification-banner__heading', { timeout: 80000 })
+            .should('include.text', 'are eligible for free school meals.');
+    
+        cy.contains('a.govuk-button', "Continue to add child details").click();
+    
+        // Enter child details
+        cy.url().should('include', '/Enter_Child_Details');
+    
+        cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
+        cy.get('[id="ChildList[0].LastName"]').type(childLastName);
+    
+        // Exactly 19 at academic year start - should fail
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+    
+        cy.contains('button', 'Save and continue').click();
+    
+        cy.url().should('include', '/Enter_Child_Details');
+    
+        cy.contains(
+            'Child 1 must be under the age of 19 at the beginning of the academic year to be eligible'
+        ).should('exist');
+    });
 });

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -1,3 +1,4 @@
+import { getValidChildDob, getInvalidChildDob } from '../../support/dateHelpers';
 describe('Full journey of creating an application through school portal through to approving in LA portal', () => {
     const parentFirstName = 'Tim';
     const parentLastName = Cypress.env('lastName');
@@ -38,9 +39,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.contains('button', 'Add another child').click();
         cy.contains('button', 'Remove').click();
         cy.contains('button', 'Save and continue').click();
@@ -184,9 +189,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.contains('button', 'Save and continue').click();
 
         //Check answers page
@@ -253,9 +262,11 @@ describe('Full journey of creating an application through school portal through 
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
     
         // Exactly 19 at academic year start - should fail
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+        const childDob = getInvalidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
     
         cy.contains('button', 'Save and continue').click();
     

--- a/tests/cypress/e2e/Admin/AdminLAHappyPath.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminLAHappyPath.spec.ts
@@ -33,8 +33,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.get('[id="ChildList[0].School"]').type('The Telford Park School');
 

--- a/tests/cypress/e2e/Admin/AdminLAHappyPath.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminLAHappyPath.spec.ts
@@ -1,3 +1,5 @@
+import { getValidChildDob } from '../../support/dateHelpers';
+
 describe('Full journey of creating an application through school portal through to approving in LA portal', () => {
     const parentFirstName = 'Tim';
     let referenceNumber: string;
@@ -33,9 +35,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.get('[id="ChildList[0].School"]').type('The Telford Park School');
 
         cy.get('#schoolList0')

--- a/tests/cypress/e2e/Admin/AdminUploadEvidence.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminUploadEvidence.spec.ts
@@ -36,8 +36,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.contains('button', 'Save and continue').click();
 
@@ -100,8 +100,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.contains('button', 'Save and continue').click();
 
@@ -140,8 +140,8 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
         cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
         cy.contains('button', 'Save and continue').click();
 

--- a/tests/cypress/e2e/Admin/AdminUploadEvidence.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminUploadEvidence.spec.ts
@@ -1,3 +1,4 @@
+import { getValidChildDob } from '../../support/dateHelpers';
 describe('Full journey of creating an application through school portal through to approving in LA portal', () => {
     const parentFirstName = 'Tim';
     const parentLastName = Cypress.env('lastName');
@@ -36,9 +37,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.contains('button', 'Save and continue').click();
 
         //Example of how to add a single file
@@ -100,9 +105,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.contains('button', 'Save and continue').click();
 
         cy.get('h1').should('include.text', 'Send supporting evidence');
@@ -140,9 +149,13 @@ describe('Full journey of creating an application through school portal through 
         cy.url().should('include', '/Enter_Child_Details');
         cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
         cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+        const childDob = getValidChildDob();
+
+        cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+        cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+        cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
         cy.contains('button', 'Save and continue').click();
 
         // Load files from fixtures folder

--- a/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
+++ b/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
@@ -1,3 +1,4 @@
+import { getValidChildDob } from '../../support/dateHelpers';
 
 describe('Keyword search validation', () => {
   const parentFirstName = 'Sinkler';
@@ -41,9 +42,13 @@ describe('Keyword search validation', () => {
     cy.url().should('include', '/Enter_Child_Details');
     cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
     cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-    cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
-    cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
-    cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
+
+    const childDob = getValidChildDob();
+
+    cy.get('[id="ChildList[0].DateOfBirth.Day"]').type(childDob.day);
+    cy.get('[id="ChildList[0].DateOfBirth.Month"]').type(childDob.month);
+    cy.get('[id="ChildList[0].DateOfBirth.Year"]').type(childDob.year);
+
     cy.contains('button', 'Save and continue').click();
 
     //skip uploading evidence

--- a/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
+++ b/tests/cypress/e2e/Admin/SearchFilterVerification.spec.ts
@@ -41,8 +41,8 @@ describe('Keyword search validation', () => {
     cy.url().should('include', '/Enter_Child_Details');
     cy.get('[id="ChildList[0].FirstName"]').type(childFirstName);
     cy.get('[id="ChildList[0].LastName"]').type(childLastName);
-    cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('01');
-    cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('01');
+    cy.get('[id="ChildList[0].DateOfBirth.Day"]').type('02');
+    cy.get('[id="ChildList[0].DateOfBirth.Month"]').type('09');
     cy.get('[id="ChildList[0].DateOfBirth.Year"]').type('2007');
     cy.contains('button', 'Save and continue').click();
 

--- a/tests/cypress/support/dateHelpers.ts
+++ b/tests/cypress/support/dateHelpers.ts
@@ -1,0 +1,28 @@
+export function getAcademicYearStart() {
+    const now = new Date();
+    const academicYear = now.getMonth() >= 4
+        ? now.getFullYear()
+        : now.getFullYear() - 1;
+
+    return new Date(academicYear, 8, 1);
+}
+
+export function getValidChildDob() {
+    const academicYearStart = getAcademicYearStart();
+
+    return {
+        day: '02',
+        month: '09',
+        year: (academicYearStart.getFullYear() - 19).toString()
+    };
+}
+
+export function getInvalidChildDob() {
+    const academicYearStart = getAcademicYearStart();
+
+    return {
+        day: '01',
+        month: '09',
+        year: (academicYearStart.getFullYear() - 19).toString()
+    };
+}


### PR DESCRIPTION
## What changed
Updated FSM full application child DOB validation rules for DEV-3317.

- Removed the lower age limit validation from the full/non-basic FSM add child details journey.
- Retained upper age validation.
- Updated validation error wording to:
  “Child 1 must be under the age of 19 at the beginning of the academic year to be eligible”

## Technical approach
DobAttribute was updated to support optional minimum age validation so the behaviour could be disabled specifically for the Child model without affecting other existing DOB validation usages.

## Validation
- Verified children under 4 can now proceed successfully.
- Verified child DOBs resulting in age 19 at academic year start still fail validation.
- Existing tests passing.