### PR TITLE
ELIG-2539 ADMIN remove "Error: check details" content from error display

### DIFF
--- a/CheckYourEligibility.Admin/Controllers/CheckController.cs
+++ b/CheckYourEligibility.Admin/Controllers/CheckController.cs
@@ -578,9 +578,11 @@ public class CheckController : BaseController
             }
         }
 
+        //Handle no evidence files selected
         if ((request.EvidenceFiles == null || !request.EvidenceFiles.Any()) && !evidenceExists)
         {
             isValid = false;
+            ModelState.AddModelError("EvidenceFiles", $"You have not selected a file");
             TempData["ErrorMessage"] = "You have not selected a file";
         }
 

--- a/CheckYourEligibility.Admin/Views/Application/FinaliseApplications.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/FinaliseApplications.cshtml
@@ -9,6 +9,22 @@
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link backLinkJS" href="@Url.Action("Index", "Home")">Back</a>
 
+    @if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div id="error-summary" class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+                <h2 class="govuk-error-summary__title">There is a problem</h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a class="govuk-error-message" href="#finaliseApplications">@errorMessage</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    }
+
     <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
             <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
@@ -38,8 +54,7 @@
         <div class="govuk-grid-column-full @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-form-group--error")">
             @if (!string.IsNullOrEmpty(errorMessage))
             {
-                ViewData["Title"] = "Error: " + errorMessage;
-                <p id="file-upload-1-error" class="govuk-error-message">
+                <p class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span> @errorMessage
                 </p>
             }
@@ -54,7 +69,7 @@
                     @Html.ActionLink("Download all files", "FinalisedApplicationsdownload", "Application", null, new { @class = "govuk-button govuk-button--secondary" })
                 </div>
 
-                <table class="govuk-table">
+                <table id="finaliseApplications" class="govuk-table">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
                             <th class="govuk-table__header" scope="col" id="select-all" aria-label="Select records"></th>

--- a/CheckYourEligibility.Admin/Views/Application/SearchResults.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/SearchResults.cshtml
@@ -40,10 +40,8 @@
 
     @if (!ViewData.ModelState.IsValid)
     {
-        ViewData["Title"] = "Error: Check Details";
         <partial name="_ValidationSummary" model="ViewData.ModelState" />
     }
-
 
     @{
         var applicationSearchJson = TempData["ApplicationSearch"] as string;

--- a/CheckYourEligibility.Admin/Views/BulkCheck/Bulk_Check.cshtml
+++ b/CheckYourEligibility.Admin/Views/BulkCheck/Bulk_Check.cshtml
@@ -10,7 +10,6 @@
 
     @if (!string.IsNullOrEmpty(errorMessage))
     {
-        ViewData["Title"] = "Error: Check Details";
         <div id="error-summary" class="govuk-error-summary" data-module="govuk-error-summary">
             <div role="alert">
                 <h2 class="govuk-error-summary__title">There is a problem</h2>
@@ -82,7 +81,7 @@
                     @if (!string.IsNullOrEmpty(errorMessage))
                     {
                         <p id="file-upload-1-error" class="govuk-error-message">
-                            <span class="govuk-visually-hidden">Error:</span> @errorMessage
+                            <span class="govuk-visually-hidden">Error: </span>@errorMessage
                         </p>
                     }
                     <div class="govuk-form-group">

--- a/CheckYourEligibility.Admin/Views/Check/Consent_Declaration.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Consent_Declaration.cshtml
@@ -18,8 +18,10 @@
                 <div class="govuk-error-summary__body">
                     <ul class="govuk-list govuk-error-summary__list">
                         <li>
-                            <a href="#consent-error">Select if the parent or guardian is with you and has given
-                                consent</a>
+                            <a href="#consent">
+                                Select if the parent or guardian is with you and has given
+                                consent
+                            </a>
                         </li>
                     </ul>
                 </div>
@@ -44,12 +46,15 @@
                         Confirm you have consent
                     </h1>
                 </legend>
-                <div id="consent-hint" class="govuk-hint">
-                    Select if the parent or guardian is with you and has given consent
-                </div>
-                @if (Model)
+                @if (!Model)
                 {
-                    <p id="consent-error" class="govuk-error-message">
+                    <div id="consent-hint" class="govuk-hint">
+                        Select if the parent or guardian is with you and has given consent
+                    </div>
+                }
+                else
+                {
+                    <p id="consent-hint" class="govuk-error-message">
                         <span class="govuk-visually-hidden">Error:</span> Select if the parent or guardian is with you
                         and has given consent
                     </p>

--- a/CheckYourEligibility.Admin/Views/Check/Enter_Child_Details.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Enter_Child_Details.cshtml
@@ -12,7 +12,6 @@
 
     @if (!ViewData.ModelState.IsValid)
     {
-        ViewData["Title"] = "Error: Check Details";
         <partial name="_ValidationSummaryChild" model="ViewData.ModelState" />
     }
 

--- a/CheckYourEligibility.Admin/Views/Check/UploadEvidence.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/UploadEvidence.cshtml
@@ -6,16 +6,16 @@
     var errorMessage = TempData["ErrorMessage"] as string;
 
     var safeModel = Model ?? new FsmApplication
-            {
-                ParentFirstName = "",
-                ParentLastName = "",
-                ParentNass = "",
-                ParentNino = "",
-                ParentDateOfBirth = "",
-                ParentEmail = "",
-                Children = new Children { ChildList = new List<Child>() },
-                Evidence = new Evidence { EvidenceList = new List<EvidenceFile>() }
-            };
+    {
+        ParentFirstName = "",
+        ParentLastName = "",
+        ParentNass = "",
+        ParentNino = "",
+        ParentDateOfBirth = "",
+        ParentEmail = "",
+        Children = new Children { ChildList = new List<Child>() },
+        Evidence = new Evidence { EvidenceList = new List<EvidenceFile>() }
+    };
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -23,17 +23,16 @@
 
     @if (!ViewData.ModelState.IsValid)
     {
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
-                There is a problem
-            </h2>
-            <div class="govuk-error-summary__body">
-                <ul class="govuk-list govuk-error-summary__list">
-                    @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
-                    {
-                        <li>@error.ErrorMessage</li>
-                    }
-                </ul>
+        <div id="error-summary" class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+                <h2 class="govuk-error-summary__title">There is a problem</h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a class="govuk-error-message" href="#fileUploadDropZone">@errorMessage</a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
     }
@@ -111,88 +110,38 @@
             }
         }
 
-        <div class="govuk-form-group">
-            <label class="govuk-label" for="EvidenceFiles">
-                Upload a file
-            </label>
+        <div id="fileUploadField" class="govuk-form-group @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-form-group--error")">
             @if (!string.IsNullOrEmpty(errorMessage))
             {
                 <p id="file-upload-1-error" class="govuk-error-message">
-                    <span class="govuk-visually-hidden">Error:</span>@errorMessage
+                    <span class="govuk-visually-hidden">Error: </span>@errorMessage
                 </p>
             }
-
-            <div class="govuk-drop-zone" data-module="govuk-file-upload">
-                <input class="govuk-file-upload" id="EvidenceFiles" name="EvidenceFiles" type="file" accept=".jpg,.jpeg,.heic,.heif,.bmp,.tif,.png,.pdf" aria-describedby="file-upload-1-error" multiple>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="fileUploadDropZone">
+                    Upload a file
+                </label>
+                <div class="govuk-drop-zone" data-module="govuk-file-upload">
+                    <input class="govuk-file-upload @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-file-upload--error")"
+                           id="fileUploadDropZone" name="EvidenceFiles" type="file" accept=".jpg,.jpeg,.heic,.heif,.bmp,.tif,.png,.pdf" aria-describedby="file-upload-1-error" multiple />
+                </div>
             </div>
         </div>
 
+        <p class="govuk-body">Your file must be:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>a JPG, JPEG, HEIC, HEIF, BMP, PNG, TIF, or PDF</li>
+            <li>smaller than 10MB</li>
+        </ul>
+
         <div class="govuk-button-group">
-            <button type="submit" asp-action="UploadEvidence" name="actionType" value="attach" class="govuk-button" data-module="govuk-button">
+            <button class="govuk-button" data-module="govuk-button">
                 Attach evidence
             </button>
 
             <a name="actionType" value="email" href="@Url.Action("Check_Answers")" class="govuk-link" data-module="govuk-button">
                 Send by email later
             </a>
-
         </div>
     </form>
-
-    @*     @if (safeModel.Evidence?.EvidenceList?.Count > 0)
-    {
-        <form method="post" asp-controller="Check" asp-action="ContinueWithoutMoreFiles">
-            <!-- Parent Details -->
-            <input type="hidden" name="ParentFirstName" value="@safeModel.ParentFirstName" />
-            <input type="hidden" name="ParentLastName" value="@safeModel.ParentLastName" />
-            <input type="hidden" name="ParentNass" value="@safeModel.ParentNass" />
-            <input type="hidden" name="ParentNino" value="@safeModel.ParentNino" />
-            <input type="hidden" name="ParentDateOfBirth" value="@safeModel.ParentDateOfBirth" />
-            <input type="hidden" name="ParentEmail" value="@safeModel.ParentEmail" />
-
-            <!-- Child details -->
-            @if (safeModel.Children?.ChildList != null)
-            {
-                for (var i = 0; i < safeModel.Children.ChildList.Count; i++)
-                {
-                    var child = safeModel.Children.ChildList[i];
-                    if (child != null)
-                    {
-                        <input type="hidden" name="Children.ChildList[@i].FirstName" value="@child.FirstName" />
-                        <input type="hidden" name="Children.ChildList[@i].LastName" value="@child.LastName" />
-                        <input type="hidden" name="Children.ChildList[@i].Day" value="@child.Day" />
-                        <input type="hidden" name="Children.ChildList[@i].Month" value="@child.Month" />
-                        <input type="hidden" name="Children.ChildList[@i].Year" value="@child.Year" />
-
-                        @if (child.School != null)
-                        {
-                            <input type="hidden" name="Children.ChildList[@i].School.URN" value="@child.School.URN" />
-                            <input type="hidden" name="Children.ChildList[@i].School.Name" value="@child.School.Name" />
-                            <input type="hidden" name="Children.ChildList[@i].School.LA" value="@child.School.LA" />
-                        }
-                    }
-                }
-            }
-
-            <!-- Evidence files -->
-            @if (safeModel.Evidence?.EvidenceList != null)
-            {
-                for (var i = 0; i < safeModel.Evidence.EvidenceList.Count; i++)
-                {
-                    var evidenceFile = safeModel.Evidence.EvidenceList[i];
-                    if (evidenceFile != null)
-                    {
-                        <input type="hidden" name="Evidence.EvidenceList[@i].FileName" value="@evidenceFile.FileName" />
-                        <input type="hidden" name="Evidence.EvidenceList[@i].FileType" value="@evidenceFile.FileType" />
-                        <input type="hidden" name="Evidence.EvidenceList[@i].StorageAccountReference" value="@evidenceFile.StorageAccountReference" />
-                    }
-                }
-            }
-
-            <button type="submit" class="govuk-button govuk-button--secondary">
-                Continue without adding more files
-            </button>
-        </form>
-    }
- *@
 </div>

--- a/CheckYourEligibility.Admin/Views/Check/UploadEvidence.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/UploadEvidence.cshtml
@@ -21,12 +21,6 @@
 <div class="govuk-grid-column-two-thirds">
     <a class="govuk-back-link backLinkJS" href="@Url.Action("Index", "Home")">Back</a>
 
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">@ViewData["Title"]</h1>
-
-    <p class="govuk-body">You will need to provide supporting evidence for this application.</p>
-    <p>Upload the evidence here or send copies by email later.</p>
-    <p>View <a href="@Url.Action("EvidenceGuidance", "Home")" class="govuk-link">guidance about supporting evidence (opens in a new window)</a>.</p>
-
     @if (!ViewData.ModelState.IsValid)
     {
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
@@ -43,6 +37,12 @@
             </div>
         </div>
     }
+
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">@ViewData["Title"]</h1>
+
+    <p class="govuk-body">You will need to provide supporting evidence for this application.</p>
+    <p>Upload the evidence here or send copies by email later.</p>
+    <p>View <a href="@Url.Action("EvidenceGuidance", "Home")" class="govuk-link">guidance about supporting evidence (opens in a new window)</a>.</p>
 
     @if (safeModel.Evidence?.EvidenceList?.Count > 0)
     {
@@ -118,7 +118,7 @@
             @if (!string.IsNullOrEmpty(errorMessage))
             {
                 <p id="file-upload-1-error" class="govuk-error-message">
-                    <span>Error:</span> @errorMessage
+                    <span class="govuk-visually-hidden">Error:</span>@errorMessage
                 </p>
             }
 

--- a/CheckYourEligibility.Admin/Views/Home/Index.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Index.cshtml
@@ -14,12 +14,6 @@
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 
-    @if (!ViewData.ModelState.IsValid)
-    {
-        ViewData["Title"] = "Error: Check Details";
-        <partial name="_ValidationSummary" model="ViewData.ModelState" />
-    }
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <span class="govuk-caption-l">@CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Model.Claims.Organisation.Name.ToLower())</span>


### PR DESCRIPTION
- Remove "Error: " from titles and validation summary messages. Add visually hidden "Error:" to inline validation messages as necessary.
- Add model error when no evidence file selected.
- Improve UploadEvidence uploader and validation summary in line with other uploaders in Admin and Parent.

https://dfedigital.atlassian.net/browse/ELIG-2539