### PR TITLE
Implement error handling for application status updates and enhance error messaging in views

### DIFF
--- a/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
@@ -745,7 +745,7 @@ public class ApplicationController : BaseController
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, $"Failed to archive application {id}");
+            _logger.LogError(ex, $"Failed to archive application {id.Replace(Environment.NewLine, "")}");
             TempData["ErrorMessage"] = "Sorry, there was a problem archiving this record. " + ex.Message;
             return RedirectToAction("ApplicationDetail", new { id });
         }
@@ -769,7 +769,7 @@ public class ApplicationController : BaseController
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, $"Failed to restore application {id}");
+            _logger.LogError(ex, $"Failed to restore application {id.Replace(Environment.NewLine, "")}");
             TempData["ErrorMessage"] = "Sorry, there was a problem restoring this record. " + ex.Message;
         }
 

--- a/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility.Admin/Controllers/ApplicationController.cs
@@ -739,9 +739,17 @@ public class ApplicationController : BaseController
         var checkAccess = await ConfirmCheckAccess(id);
         if (checkAccess != null) return checkAccess;
 
-        await _adminGateway.PatchApplicationStatus(id, ApplicationStatus.Archived);
+        try
+        {
+            await _adminGateway.PatchApplicationStatus(id, ApplicationStatus.Archived);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Failed to archive application {id}");
+            TempData["ErrorMessage"] = "Sorry, there was a problem archiving this record. " + ex.Message;
+            return RedirectToAction("ApplicationDetail", new { id });
+        }
 
-        var response = await _adminGateway.GetApplication(id);
         return RedirectToAction("ApplicationArchived", new { id });
     }
 
@@ -750,13 +758,19 @@ public class ApplicationController : BaseController
         var checkAccess = await ConfirmCheckAccess(id);
         if (checkAccess != null) return checkAccess;
 
-        var currentApplication = await _adminGateway.GetApplication(id);
-        if (currentApplication.Data.Status == ApplicationStatus.Archived)
+        try
         {
-            await _adminGateway.RestoreApplicationStatus(id);
-
-            var response = await _adminGateway.GetApplication(id);
-            TempData["restored"] = true;
+            var currentApplication = await _adminGateway.GetApplication(id);
+            if (currentApplication.Data.Status == ApplicationStatus.Archived)
+            {
+                await _adminGateway.RestoreApplicationStatus(id);
+                TempData["restored"] = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Failed to restore application {id}");
+            TempData["ErrorMessage"] = "Sorry, there was a problem restoring this record. " + ex.Message;
         }
 
         return RedirectToAction("ApplicationDetail", new { id });

--- a/CheckYourEligibility.Admin/Gateways/BaseGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/BaseGateway.cs
@@ -297,9 +297,11 @@ public class BaseGateway
     protected virtual async Task LogApiErrorInternal(HttpResponseMessage task, string method, string uri, string data)
     {
         var guid = Guid.NewGuid().ToString();
+        string? apiErrorTitle = null;
         if (task?.Content != null)
         {
             var jsonString = await task.Content.ReadAsStringAsync();
+            apiErrorTitle = TryGetApiErrorTitle(jsonString);
             _telemetry.TrackEvent($"Ui_Calling_API {method} failure",
                 new Dictionary<string, string>
                 {
@@ -316,8 +318,9 @@ public class BaseGateway
                 new Dictionary<string, string> { { "LogId", guid }, { "Address", uri } });
         }
 
-        throw new Exception(
-            $"Ui_Calling_API Failure:-{method} , your issue has been logged please use the following reference:- {guid}");
+        throw new Exception(!string.IsNullOrWhiteSpace(apiErrorTitle)
+            ? $"{apiErrorTitle} (reference:- {guid})"
+            : $"Ui_Calling_API Failure:-{method} , your issue has been logged please use the following reference:- {guid}");
     }
 
     [ExcludeFromCodeCoverage(Justification =
@@ -325,9 +328,11 @@ public class BaseGateway
     protected virtual async Task LogApiErrorInternal(HttpResponseMessage task, string method, string uri)
     {
         var guid = Guid.NewGuid().ToString();
+        string? apiErrorTitle = null;
         if (task.Content != null)
         {
             var jsonString = await task.Content.ReadAsStringAsync();
+            apiErrorTitle = TryGetApiErrorTitle(jsonString);
             _telemetry.TrackEvent($"Ui_Calling_API {method} failure",
                 new Dictionary<string, string>
                 {
@@ -343,7 +348,32 @@ public class BaseGateway
                 new Dictionary<string, string> { { "LogId", guid }, { "Address", uri } });
         }
 
-        throw new Exception(
-            $"Ui_Calling_API Failure:-{method} , your issue has been logged please use the following reference:- {guid}");
+        throw new Exception(!string.IsNullOrWhiteSpace(apiErrorTitle)
+            ? $"{apiErrorTitle} (reference:- {guid})"
+            : $"Ui_Calling_API Failure:-{method} , your issue has been logged please use the following reference:- {guid}");
+    }
+
+    private static string? TryGetApiErrorTitle(string jsonString)
+    {
+        try
+        {
+            var errorResponse = JsonConvert.DeserializeObject<ApiErrorResponse>(jsonString);
+            return errorResponse?.Errors?.FirstOrDefault()?.Title;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private class ApiErrorResponse
+    {
+        public List<ApiError>? Errors { get; set; }
+    }
+
+    private class ApiError
+    {
+        public string? Title { get; set; }
+        public int Status { get; set; }
     }
 }

--- a/CheckYourEligibility.Admin/Views/Application/ApplicationDetail.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/ApplicationDetail.cshtml
@@ -1,12 +1,32 @@
-﻿@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
+﻿@using CheckYourEligibility.Admin.Domain.Enums
+@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
 
 @{
     ViewData["Title"] = Model.ParentName;
     bool restored = (TempData["restored"] as bool?) ?? false;
+    var errorMessage = TempData["ErrorMessage"] as string;
 }
 
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link backLinkJS" href="@Url.Action("SearchResults", "Application")">Back</a>
+
+    @if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+                <h2 class="govuk-error-summary__title">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <p>@errorMessage</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    }
 
     @if (restored)
     {
@@ -24,7 +44,7 @@
         </div>
     }
 
-    @if (@Model.Status.Equals("Archived"))
+    @if (Model.Status == ApplicationStatus.Archived)
     {
         <div class="govuk-error-summary" data-module="govuk-error-summary">
             <div role="alert">
@@ -46,7 +66,7 @@
         <div class="moj-page-header-actions__actions">
             <div class="moj-button-menu">
                 <div class="moj-button-menu__wrapper">
-                    @if (Model.Status.Equals("Archived"))
+                    @if (Model.Status == ApplicationStatus.Archived)
                     {
                         @Html.ActionLink("Restore record", "ApplicationRestoreSend", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--secondary moj-button-menu__item" })
                     }
@@ -59,7 +79,7 @@
         </div>
     </div>
 
-    @if (Model.Status.Equals("EvidenceNeeded"))
+    @if (Model.Status == ApplicationStatus.EvidenceNeeded)
     {
         <div class="govuk-width-container">
             <div class="govuk-grid-row">

--- a/CheckYourEligibility.Admin/Views/Application/ApplicationDetailAppeal.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/ApplicationDetailAppeal.cshtml
@@ -1,4 +1,5 @@
-﻿@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
+﻿@using CheckYourEligibility.Admin.Domain.Enums
+@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
 
 @{
     ViewData["Title"] = Model.ParentName;
@@ -20,7 +21,7 @@
             </div>
         </div>
     </div>
-    @if (Model.Status.Equals("EvidenceNeeded"))
+    @if (Model.Status == ApplicationStatus.EvidenceNeeded)
     {
         <div class="govuk-width-container">
             <div class="govuk-grid-row">

--- a/CheckYourEligibility.Admin/Views/Application/ApplicationDetailFinalise.cshtml
+++ b/CheckYourEligibility.Admin/Views/Application/ApplicationDetailFinalise.cshtml
@@ -1,4 +1,5 @@
-﻿@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
+﻿@using CheckYourEligibility.Admin.Domain.Enums
+@model CheckYourEligibility.Admin.ViewModels.ApplicationDetailViewModel
 
 @{
     ViewData["Title"] = Model.ParentName;
@@ -7,7 +8,7 @@
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link backLinkJS" href="@Url.Action("FinaliseApplications", "Application")">Back</a>
 
-    @if (@Model.Status.Equals("Archived"))
+    @if (Model.Status == ApplicationStatus.Archived)
     {
         <div class="govuk-error-summary" data-module="govuk-error-summary">
             <div role="alert">
@@ -28,7 +29,7 @@
         <div class="moj-page-header-actions__actions">
             <div class="moj-button-menu">
                 <div class="moj-button-menu__wrapper">
-                    @if (Model.Status.Equals("Archived"))
+                    @if (Model.Status == ApplicationStatus.Archived)
                     {
                         @Html.ActionLink("Restore record", "ApplicationRestoreSend", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--secondary moj-button-menu__item" })
                     }


### PR DESCRIPTION
This is an optional PR. It is mainly to show the error message when someone tries to restore an application with no history of status i.e. an application that was imported directly.

The API now has a fix for this and we can think of adding a status history for the existing imported applications via a SQL script.

Until that decision is taken, instead of showing an error message to the user when restore is clicked

<img width="1698" height="791" alt="image" src="https://github.com/user-attachments/assets/7c4a6cb0-7544-4158-a9a8-5ca4dd5edd1e" />

this PR will show a message

<img width="1917" height="1293" alt="image" src="https://github.com/user-attachments/assets/12c666c2-6a37-4fe8-a9a4-6e1085f8d3fc" />
  