### PR TITLE
ELIG-3345-FSM-Welsh-User-Update-content-on-outcome-and-guidance-pages

### DIFF
--- a/CheckYourEligibility.Admin/Boundary/Responses/LocalAuthoritySettingsResponse.cs
+++ b/CheckYourEligibility.Admin/Boundary/Responses/LocalAuthoritySettingsResponse.cs
@@ -6,6 +6,8 @@ public sealed class LocalAuthoritySettingsResponse
 {
     public bool SchoolCanReviewEvidence { get; set; }
 
+    public string? Region { get; set; }
+
     public IEnumerable<EligibilityPolicyAssignment> EligibilityPolicies { get; set; }
 }
 

--- a/CheckYourEligibility.Admin/Controllers/BaseController.cs
+++ b/CheckYourEligibility.Admin/Controllers/BaseController.cs
@@ -79,11 +79,14 @@ public class BaseController : Controller
     public async Task<EligibilityPolicyAssignment> GetFreeSchoolMealsPolicy()
     {
         EligibilityPolicyAssignment policy;
+        string laRegion;
         var defaultPolicy = new EligibilityPolicyAssignment
         {
             CheckType = CheckEligibilityType.FreeSchoolMeals.ToString(),
             EligibilityCriteria = EligibilityCriteria.expanded // Default to standard if there's an error
         };
+
+        string defaultRegion = "undefined";
 
         try
         {
@@ -104,6 +107,7 @@ public class BaseController : Controller
 
             // Check if the policy is already cached in the session
             var cachedPolicy = HttpContext.Session.GetString("FreeSchoolMealsPolicy");
+            var cachedLaRegion = HttpContext.Session.GetString("LocalAuthorityRegion");
             if (string.IsNullOrEmpty(cachedPolicy) || cachedPolicy == "null")
             {
                 // If not cached, and a LA ID is provided retrieve from the Local Authority API
@@ -111,18 +115,22 @@ public class BaseController : Controller
                 {
                     var localAuthoritySettings = await _localAuthoritySettingsGateway.GetLocalAuthoritySettingsAsync(laID);
                     policy = localAuthoritySettings?.EligibilityPolicies?.FirstOrDefault(p => p.CheckType == CheckEligibilityType.FreeSchoolMeals.ToString());
+                    laRegion = localAuthoritySettings.Region;
                 }
                 else
                 {
                     policy = defaultPolicy;
+                    laRegion = defaultRegion;
                 }
                 // Cache the policy in the session for future requests
                 HttpContext.Session.SetString("FreeSchoolMealsPolicy", JsonConvert.SerializeObject(policy));
+                HttpContext.Session.SetString("LocalAuthorityRegion", laRegion);
             }
             else
             {
                 // If cached, deserialize it from the session
                 policy = JsonConvert.DeserializeObject<EligibilityPolicyAssignment>(cachedPolicy);
+                laRegion = cachedLaRegion;
             }
         }
         catch (Exception ex)
@@ -130,9 +138,11 @@ public class BaseController : Controller
             // Log the exception
             Console.WriteLine($"Error retrieving Free School Meals policy: {ex.Message}");
             policy = defaultPolicy;
+            laRegion = defaultRegion;
         }
         // Store the policy in ViewBag for easy use in views
         ViewBag.FreeSchoolMealsPolicy = policy;
+        ViewBag.LaRegion = laRegion;
 
         return policy;
     }

--- a/CheckYourEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckYourEligibility.Admin/Controllers/HomeController.cs
@@ -112,5 +112,10 @@ public class HomeController : BaseController
 
     public IActionResult Rechecks() => View("Guidance_steps/Rechecks");
 
-    public IActionResult Expansion() => View("Guidance_steps/Expansion");
+    public async Task<IActionResult> Expansion()
+    {
+        await IsExpandedFSMEnabled();
+
+        return View("Guidance_steps/Expansion");
+    }
 }

--- a/CheckYourEligibility.Admin/Domain/Constants/LocalAuthorityRegion.cs
+++ b/CheckYourEligibility.Admin/Domain/Constants/LocalAuthorityRegion.cs
@@ -1,0 +1,7 @@
+﻿namespace CheckYourEligibility.Admin.Domain.Constants
+{
+    public static class LocalAuthorityRegion
+    {
+        public const string Wales = "Wales (pseudo)";
+    }
+}

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible.cshtml
@@ -15,6 +15,8 @@
         "yyyy-MM-dd",
         CultureInfo.DefaultThreadCurrentCulture
     ) : DateTime.UtcNow;
+
+    bool isWelsh = false;
 }
 
 <div class="govuk-grid-column-full">
@@ -87,7 +89,7 @@
                 <p class="govuk-body">
                     @Html.ActionLink("How and when to complete annual rechecks", "Rechecks", "Home", null, new { @class = "govuk-link" })
 
-                    @if (fsmPolicy.EligibilityCriteria == EligibilityCriteria.expanded)
+                    @if (fsmPolicy.EligibilityCriteria == EligibilityCriteria.expanded || isWelsh)
                     {
                         <div class="govuk-inset-text">
                             <p><strong>Targeted and expanded free school meals</strong></p>
@@ -96,20 +98,36 @@
                             <p>
                                 <strong class="govuk-tag govuk-tag--purple tag-wider">Eligible @CheckEligibilityExpandedTier.targeted.ToString():</strong>
                                 this covers children in households in receipt of Universal Credit with annual household earnings of £7,400 or less.
-                                These children will attract pupil premium and other disadvantage funding for their schools.
-                                Other education entitlements, such as the holiday activities and food programme (HAF) and the ‘extended rights’ element of school travel assistance, will be based on targeted free school meals.
+
+                                @if (isWelsh)
+                                {
+                                    <span>
+                                        These children will attract the pupil development grant and other disadvantage funding for their schools.
+                                        Other education entitlements such as the Food and Fun, School Holiday Enrichment Programme will be based on targeted free school meals.
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span>
+                                        These children will attract pupil premium and other disadvantage funding for their schools.
+                                        Other education entitlements, such as the holiday activities and food programme(HAF) and the ‘extended rights’ element of school travel assistance, will be based on targeted free school meals.
+                                    </span>
+                                }
                             </p>
                             <p>
                                 <strong class="govuk-tag govuk-tag--green tag-wider">Eligible @CheckEligibilityExpandedTier.expanded.ToString():</strong>
                                 this covers children who are in households receiving Universal Credit with annual household earnings exceeding £7,400.
                                 Children will be entitled to free school meals only.
                             </p>
-                            <p>
-                                For more information, read
-                                <a href="https://www.gov.uk/government/publications/free-school-meals-guidance-for-schools-and-local-authorities" class="govuk-link" target="_blank" rel="noopener noreferrer">
-                                    Free school meals: guidance for schools and local authorities.
-                                </a>
-                            </p>
+                            @if (!isWelsh)
+                            {
+                                <p>
+                                    For more information, read
+                                    <a href="https://www.gov.uk/government/publications/free-school-meals-guidance-for-schools-and-local-authorities" class="govuk-link" target="_blank" rel="noopener noreferrer">
+                                        Free school meals: guidance for schools and local authorities.
+                                    </a>
+                                </p>
+                            }
                         </div>
                     }
                 </p>

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Eligible.cshtml
@@ -1,5 +1,6 @@
 ﻿@using System.Globalization
 @using CheckYourEligibility.Admin.Boundary.Responses
+@using CheckYourEligibility.Admin.Domain.Constants
 @using CheckYourEligibility.Admin.Domain.DfeSignIn
 @using CheckYourEligibility.Admin.Domain.Enums
 @model TieredOutcome
@@ -16,7 +17,8 @@
         CultureInfo.DefaultThreadCurrentCulture
     ) : DateTime.UtcNow;
 
-    bool isWelsh = false;
+    var laRegion = ViewBag.LaRegion as string;
+    bool isWelshLA = laRegion == LocalAuthorityRegion.Wales;
 }
 
 <div class="govuk-grid-column-full">
@@ -89,7 +91,7 @@
                 <p class="govuk-body">
                     @Html.ActionLink("How and when to complete annual rechecks", "Rechecks", "Home", null, new { @class = "govuk-link" })
 
-                    @if (fsmPolicy.EligibilityCriteria == EligibilityCriteria.expanded || isWelsh)
+                    @if (fsmPolicy.EligibilityCriteria == EligibilityCriteria.expanded || isWelshLA)
                     {
                         <div class="govuk-inset-text">
                             <p><strong>Targeted and expanded free school meals</strong></p>
@@ -99,7 +101,7 @@
                                 <strong class="govuk-tag govuk-tag--purple tag-wider">Eligible @CheckEligibilityExpandedTier.targeted.ToString():</strong>
                                 this covers children in households in receipt of Universal Credit with annual household earnings of £7,400 or less.
 
-                                @if (isWelsh)
+                                @if (isWelshLA)
                                 {
                                     <span>
                                         These children will attract the pupil development grant and other disadvantage funding for their schools.
@@ -119,7 +121,7 @@
                                 this covers children who are in households receiving Universal Credit with annual household earnings exceeding £7,400.
                                 Children will be entitled to free school meals only.
                             </p>
-                            @if (!isWelsh)
+                            @if (!isWelshLA)
                             {
                                 <p>
                                     For more information, read

--- a/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Expansion.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Expansion.cshtml
@@ -1,7 +1,9 @@
-﻿@{
+﻿@using CheckYourEligibility.Admin.Domain.Constants
+@{
     ViewData["Title"] = "Targeted and expanded free school meals";
 
-    bool isWelsh = false;
+    var laRegion = ViewBag.LaRegion as string;
+    bool isWelshLA = laRegion == LocalAuthorityRegion.Wales;
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -20,7 +22,7 @@
     <p>These children:</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>will get free school meals</li>
-        @if (isWelsh)
+        @if (isWelshLA)
         {
             <li>will attract the pupil development grant and other disadvantage funding for their schools</li>
             <li>
@@ -45,7 +47,7 @@
         This covers children who are in households receiving Universal Credit with annual household earnings exceeding £7,400. Children will be entitled to free school meals only.
     </p>
 
-    @if (!isWelsh)
+    @if (!isWelshLA)
     {
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
         <h2 class="govuk-heading-m">More information</h2>

--- a/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Expansion.cshtml
+++ b/CheckYourEligibility.Admin/Views/Home/Guidance_steps/Expansion.cshtml
@@ -1,5 +1,7 @@
 ﻿@{
     ViewData["Title"] = "Targeted and expanded free school meals";
+
+    bool isWelsh = false;
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -18,11 +20,21 @@
     <p>These children:</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>will get free school meals</li>
-        <li>will attract pupil premium and other disadvantage funding for their schools </li>
-        <li>
-            may be eligible for additional support, such as the holiday activities and food programme (HAF) and the
-            ‘extended rights’ element of school travel assistance
-        </li>
+        @if (isWelsh)
+        {
+            <li>will attract the pupil development grant and other disadvantage funding for their schools</li>
+            <li>
+                may be eligible for additional support such as the Food and Fun, School Holiday Enrichment Programme
+            </li>
+        }
+        else
+        {
+            <li>will attract pupil premium and other disadvantage funding for their schools </li>
+            <li>
+                may be eligible for additional support, such as the holiday activities and food programme (HAF) and the
+                ‘extended rights’ element of school travel assistance
+            </li>
+        }
     </ul>
 
     <h2 class="govuk-heading-m">Expanded free school meals</h2>
@@ -32,12 +44,16 @@
     <p>
         This covers children who are in households receiving Universal Credit with annual household earnings exceeding £7,400. Children will be entitled to free school meals only.
     </p>
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m">More information</h2>
-    <p>
-        For full details, read
-        <a href="https://www.gov.uk/government/publications/free-school-meals-guidance-for-schools-and-local-authorities" class="govuk-link" target="_blank" rel="noopener noreferrer">
-            Free school meals guidance for schools and local authorities.
-        </a>
-    </p>
+
+    @if (!isWelsh)
+    {
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        <h2 class="govuk-heading-m">More information</h2>
+        <p>
+            For full details, read
+            <a href="https://www.gov.uk/government/publications/free-school-meals-guidance-for-schools-and-local-authorities" class="govuk-link" target="_blank" rel="noopener noreferrer">
+                Free school meals guidance for schools and local authorities.
+            </a>
+        </p>
+    }
 </div>


### PR DESCRIPTION
- Content changes for Welsh policy users. 
- Temporary isWelsh variable on each page to be removed when we know how we will define a user as Welsh.
- Make local authority region available to determine Welsh LA's. 
- Update temporary placeholder settings to use the retrieved value.

https://dfedigital.atlassian.net/browse/ELIG-3345