### PR TITLE
ELIG-3429 Fix FSM report history content, pagination and tests

### DIFF
--- a/CheckYourEligibility.Admin/Views/Check/Report/ReportPagination.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/ReportPagination.cshtml
@@ -4,14 +4,25 @@
     var currentPage = Model.PageNumber;
     var pageSize = Model.PageSize;
     var totalRecords = Model.TotalNumberOfRecords;
-
-    var totalPages = (int)Math.Ceiling((double)totalRecords / pageSize);
+    var totalPages = Math.Max(1, (int)Math.Ceiling((double)totalRecords / pageSize));
 }
 
-@if (totalPages > 1)
-{
-    <nav class="govuk-pagination" aria-label="Pagination">
-
+<nav class="govuk-pagination" aria-label="Pagination">
+    @if (totalPages == 1)
+    {
+        <ul class="govuk-pagination__list">
+            <li class="govuk-pagination__item govuk-pagination__item--current">
+                <a class="govuk-link govuk-pagination__link"
+                   href="@Url.Action("Reports", "EligibilityCheckReporting", new { PageNumber = 1 })"
+                   aria-label="Page 1"
+                   aria-current="page">
+                    1
+                </a>
+            </li>
+        </ul>
+    }
+    else
+    {
         @if (currentPage > 1)
         {
             <div class="govuk-pagination__prev">
@@ -26,10 +37,10 @@
         }
 
         <ul class="govuk-pagination__list">
-
             <li class="govuk-pagination__item @(currentPage == 1 ? "govuk-pagination__item--current" : "")">
                 <a class="govuk-link govuk-pagination__link"
                    href="@Url.Action("Reports", "EligibilityCheckReporting", new { PageNumber = 1 })"
+                   aria-label="Page 1"
                    aria-current="@(currentPage == 1 ? "page" : null)">
                     1
                 </a>
@@ -42,11 +53,14 @@
                 </li>
             }
 
-            @for (var i = Math.Max(2, currentPage - 1); i <= Math.Min(totalPages - 1, currentPage + 1); i++)
+            @for (var i = Math.Max(2, currentPage - 1);
+                  i <= Math.Min(totalPages - 1, currentPage + 1);
+                  i++)
             {
                 <li class="govuk-pagination__item @(currentPage == i ? "govuk-pagination__item--current" : "")">
                     <a class="govuk-link govuk-pagination__link"
                        href="@Url.Action("Reports", "EligibilityCheckReporting", new { PageNumber = i })"
+                       aria-label="Page @i"
                        aria-current="@(currentPage == i ? "page" : null)">
                         @i
                     </a>
@@ -63,6 +77,7 @@
             <li class="govuk-pagination__item @(currentPage == totalPages ? "govuk-pagination__item--current" : "")">
                 <a class="govuk-link govuk-pagination__link"
                    href="@Url.Action("Reports", "EligibilityCheckReporting", new { PageNumber = totalPages })"
+                   aria-label="Page @totalPages"
                    aria-current="@(currentPage == totalPages ? "page" : null)">
                     @totalPages
                 </a>
@@ -81,11 +96,14 @@
                 </a>
             </div>
         }
-    </nav>
+    }
+</nav>
 
+@if (totalRecords > 1)
+{
     <p class="moj-pagination__results">
         Showing <b>@((currentPage - 1) * pageSize + 1)</b> to
-        <b>@(Math.Min(currentPage * pageSize, totalRecords))</b> of
+        <b>@Math.Min(currentPage * pageSize, totalRecords)</b> of
         <b>@totalRecords</b> records
     </p>
 }

--- a/CheckYourEligibility.Admin/Views/Check/Report/Report_History.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Report/Report_History.cshtml
@@ -12,9 +12,6 @@
     <a class="govuk-button" href="@Url.Action("Create_Report", "EligibilityCheckReporting")">Generate report</a>
     <p>If the status of a report is 'in progress', refresh the page to see if generating the report has completed. </p>
     <table class="govuk-table govuk-table--small-text-until-tablet">
-        <caption class="govuk-table__caption govuk-table__caption--s govuk-!-margin-bottom-4">
-            Showing @Model.TotalNumberOfRecords reports generated in the last 7 days
-        </caption>
 
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
@@ -37,7 +34,7 @@
                     var item = row.Item;
                     var status = row.StatusBanner;
 
-                    <tr class="govuk-table__row">
+                    <tr class="govuk-table__row" data-report-id="@item.ReportID">
                         <td class="govuk-table__cell">
                             @item.ReportGeneratedDate.ToString("d MMM yyyy")
                         </td>

--- a/CheckYourEligibility.Admin/Views/Start/UserGuidance.cshtml
+++ b/CheckYourEligibility.Admin/Views/Start/UserGuidance.cshtml
@@ -142,7 +142,7 @@
 
             <h2 class="govuk-heading-m" id="1.4">4. Generating reports </h2>
 
-            <p>This section of the service shows reports generated in the last 7 days, when the report was generated and who generated it.  </p>
+            <p>This section of the service shows generated reports, including when each report was generated and who generated it. </p>
 
             <p>Each individual report includes the: </p>
 

--- a/tests/cypress/e2e/Admin/AdminFSMReporting.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFSMReporting.spec.ts
@@ -1,54 +1,149 @@
 describe('Admin FSM Reporting', () => {
-    const today = new Date().toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric'
-    });
+    const reportRows = '.govuk-table tbody tr[data-report-id]';
+
+    const getReportIds = ($tbody: JQuery<HTMLElement>): string[] =>
+        Array.from($tbody[0].querySelectorAll<HTMLTableRowElement>('tr[data-report-id]'))
+            .map((row) => row.dataset.reportId)
+            .filter((reportId): reportId is string => Boolean(reportId));
+
+    const waitForReportToComplete = (
+        reportId: string,
+        attemptsRemaining = 40
+    ): Cypress.Chainable<JQuery<HTMLElement>> => {
+        return cy.get(`tr[data-report-id="${reportId}"]`).then(($row) => {
+            const status = $row.find('.govuk-tag').text().trim();
+
+            if (status === 'Complete') {
+                return cy.wrap($row);
+            }
+
+            if (status.includes('System error')) {
+                throw new Error(`Report ${reportId} failed to generate`);
+            }
+
+            if (attemptsRemaining === 0) {
+                throw new Error(`Report ${reportId} did not complete in time`);
+            }
+
+            return cy.wait(2000)
+                .then(() => cy.reload())
+                .then(() => waitForReportToComplete(reportId, attemptsRemaining - 1));
+        });
+    };
 
     beforeEach(() => {
         cy.checkSession('basic');
-        cy.visit((Cypress.config().baseUrl ?? "") + "/home");
-        cy.wait(1);
+        cy.visit((Cypress.config().baseUrl ?? '') + '/home');
         cy.get('.govuk-caption-l').should('include.text', 'Manchester City Council');
     });
 
-    it('Can generate FSM report with new date range and check type options', () => {
-        
+    it('Can generate, download and delete an FSM report', () => {
+        let existingReportIds: string[] = [];
+        let generatedReportId = '';
+
         cy.contains('a.dfe-card-link--header', 'Reports').click();
         cy.get('.govuk-heading-l').should('include.text', 'Report history');
 
+        cy.get('.govuk-table tbody').then(($tbody) => {
+            existingReportIds = getReportIds($tbody);
+        });
+
         cy.contains('Generate report').click();
         cy.url().should('include', '/EligibilityCheckReporting/Create_Report');
+        cy.get('.govuk-heading-l').should('include.text', 'Generate a report');
+        cy.get('#StartDate\\.Day').should('not.exist');
+        cy.get('#StartDate\\.Month').should('not.exist');
+        cy.get('#StartDate\\.Year').should('not.exist');
+        cy.get('#EndDate\\.Day').should('not.exist');
+        cy.get('#EndDate\\.Month').should('not.exist');
+        cy.get('#EndDate\\.Year').should('not.exist');
 
-        cy.get("#StartDate\\.Day").should('not.exist');
-        cy.get("#StartDate\\.Month").should('not.exist');
-        cy.get("#StartDate\\.Year").should('not.exist');
-        cy.get("#EndDate\\.Day").should('not.exist');
-        cy.get("#EndDate\\.Month").should('not.exist');
-        cy.get("#EndDate\\.Year").should('not.exist');
+        cy.get('select[name="DateRange"]')
+            .should('be.visible')
+            .find('option')
+            .should('have.length', 1)
+            .and('contain.text', 'Last 30 days');
 
-        cy.get('select[name="DateRange"]').should('be.visible');
-        cy.get('select[name="DateRange"]').find('option').should('have.length', 1);
-        cy.get('select[name="DateRange"]').find('option').should('contain.text', 'Last 30 days');
+        cy.get('select[name="CheckType"]')
+            .should('be.visible')
+            .find('option')
+            .should('have.length', 3);
 
-        cy.get('select[name="CheckType"]').should('be.visible');
-        cy.get('select[name="CheckType"]').find('option').should('have.length', 3);
-        cy.get('select[name="CheckType"]').find('option').should('contain.text', 'All checks');
-        cy.get('select[name="CheckType"]').find('option').should('contain.text', 'Individual checks');
-        cy.get('select[name="CheckType"]').find('option').should('contain.text', 'Batch checks');
+        cy.get('select[name="CheckType"]').find('option')
+            .should('contain.text', 'All checks')
+            .and('contain.text', 'Individual checks')
+            .and('contain.text', 'Batch checks');
 
         cy.contains('Generate report').click();
 
-        cy.url({ timeout: 80000 }).should('include', '/EligibilityCheckReporting/Reports');
+        cy.url({ timeout: 80000 })
+            .should('include', '/EligibilityCheckReporting/Reports');
 
-        cy.get('.govuk-table').should('be.visible');
-        cy.get('.govuk-table tbody tr').should('have.length.greaterThan', 0);
+        cy.get('.govuk-table tbody')
+            .should(($tbody) => {
+                const newReportIds = getReportIds($tbody)
+                    .filter((reportId) => !existingReportIds.includes(reportId));
 
-        // The latest report should be at the top
-        cy.get('.govuk-table tbody tr:first-child').within(() => {
-            // Check that the first column has today's date
-            cy.get('td:first-child').should('contain.text', today);
+                expect(newReportIds, 'new report IDs').to.have.length(1);
+            })
+            .then(($tbody) => {
+                generatedReportId = getReportIds($tbody)
+                    .find((reportId) => !existingReportIds.includes(reportId))!;
+
+                expect(generatedReportId, 'generated report ID').not.to.be.empty;
+            });
+
+        cy.then(() => waitForReportToComplete(generatedReportId));
+
+        cy.intercept(
+            'GET',
+            '**/EligibilityCheckReporting/Download_Report?reportId=*'
+        ).as('downloadReport');
+
+        cy.then(() => {
+            cy.get(`tr[data-report-id="${generatedReportId}"]`).within(() => {
+                cy.contains('a', 'Download report').click();
+            });
         });
+
+        cy.wait('@downloadReport').then(({ response }) => {
+            expect(response?.statusCode).to.eq(200);
+            expect(response?.headers['content-type']).to.include('text/csv');
+
+            const contentDisposition =
+                response?.headers['content-disposition'] as string;
+
+            const filenameMatch =
+                contentDisposition.match(/filename="?([^";]+\.csv)"?/i);
+
+            expect(filenameMatch, 'download filename').not.to.be.null;
+
+            const filename = filenameMatch![1];
+
+            cy.readFile(`cypress/downloads/${filename}`, {
+                timeout: 20000
+            })
+                .should('not.be.empty')
+                .and('contain', 'Parent Surname');
+        });
+
+        cy.then(() => {
+            cy.get(`tr[data-report-id="${generatedReportId}"]`).within(() => {
+                cy.contains('a', 'Delete').click();
+            });
+        });
+
+        cy.url()
+            .should('include', '/EligibilityCheckReporting/Delete_Report_Confirmation');
+
+        cy.contains('button', 'Delete report').click();
+
+        cy.url({ timeout: 80000 })
+            .should('include', '/EligibilityCheckReporting/Reports');
+
+        cy.get('.govuk-table tbody')
+            .find(`tr[data-report-id="${generatedReportId}"]`)
+            .should('not.exist');
     });
 
     it('Can view historical reports on reports page', () => {
@@ -64,55 +159,17 @@ describe('Admin FSM Reporting', () => {
             cy.contains('th', 'Status').should('be.visible');
         });
 
-        cy.get('.govuk-table tbody tr').each(($row) => {
+        cy.get(reportRows).each(($row) => {
             cy.wrap($row).within(() => {
-                cy.get('td').then(($cells) => {
-                    const statusCell = $cells[$cells.length - 2]; // Status is second to last
-                    const resultsCell = $cells[4]; // Number of results column
-                    const statusText = statusCell.textContent;
-
-                    if (statusText.includes('Complete')) {
+                cy.get('.govuk-tag').invoke('text').then((status) => {
+                    if (status.trim() === 'Complete') {
                         cy.contains('a', 'Download report').should('be.visible');
                         cy.contains('a', 'Delete').should('be.visible');
-                    }     
+                    }
                 });
             });
         });
+
         cy.get('nav.govuk-pagination').should('be.visible');
-     });
-    it('Can delete a report from the reports page', () => {
-        cy.contains('a.dfe-card-link--header', 'Reports').click();
-        cy.get('.govuk-heading-l').should('include.text', 'Report history');
-        
-        cy.get('.govuk-table tbody tr:first-child').within(() => {
-            cy.get('td').then(($cells) => {
-                const statusCell = $cells[$cells.length - 2]; // Status is second to last
-                const statusText = statusCell.textContent?.trim();
-                if (statusText?.includes('In progress')) {
-                    cy.wrap(null).then(() => {
-                        const checkStatusAndRefresh = () => {
-                            cy.get('.govuk-table tbody tr:first-child').within(() => {
-                                cy.get('td').then(($newCells) => {
-                                    const newStatusCell = $newCells[$newCells.length - 2];
-                                    const newStatusText = newStatusCell.textContent?.trim(); 
-                                    if (newStatusText?.includes('In progress')) {
-                                        cy.reload();
-                                        cy.wait(2000);
-                                        checkStatusAndRefresh();
-                                    }
-                                });
-                            });
-                        };
-                        checkStatusAndRefresh();
-                    });
-                }
-            });
-        });
-        cy.get('.govuk-table tbody tr').first().within(() => {
-            cy.contains('a', 'Delete').click();
-        });
-        cy.url().should('include', '/EligibilityCheckReporting/Delete_Report_Confirmation');
-        cy.contains('button', 'Delete report').click();
-        cy.url({ timeout: 80000 }).should('include', '/EligibilityCheckReporting/Reports');
     });
 });


### PR DESCRIPTION
## Summary

- Removed the incorrect statement that reports are limited to the last 7 days
- Updated report history pagination to remain visible when there is only one page
- Updated related reporting guidance
- Added report IDs to history rows so tests can identify the report they generated
- Updated Cypress coverage to wait for the exact report to complete, download its CSV and delete it

## Testing

- All 242 .NET tests pass
- Full Cypress test suite passes
- Verified the incorrect seven-day report wording is removed
- Verified pagination remains visible with one page
- Verified the standard results summary displays correctly
- Verified the updated report guidance
- Verified a generated report is identified, awaited until complete, downloaded and deleted
- Multi-page Previous/Next regression check to be completed in DEV