### PR TITLE
3429 follow up: Allow empty report history in Cypress test

### DIFF
--- a/tests/cypress/e2e/Admin/AdminFSMReporting.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFSMReporting.spec.ts
@@ -1,5 +1,4 @@
-describe('Admin FSM Reporting', () => {
-    const reportRows = '.govuk-table tbody tr[data-report-id]';
+describe('Admin FSM Reporting', () => {   
 
     const getReportIds = ($tbody: JQuery<HTMLElement>): string[] =>
         Array.from($tbody[0].querySelectorAll<HTMLTableRowElement>('tr[data-report-id]'))
@@ -159,13 +158,17 @@ describe('Admin FSM Reporting', () => {
             cy.contains('th', 'Status').should('be.visible');
         });
 
-        cy.get(reportRows).each(($row) => {
-            cy.wrap($row).within(() => {
-                cy.get('.govuk-tag').invoke('text').then((status) => {
-                    if (status.trim() === 'Complete') {
-                        cy.contains('a', 'Download report').should('be.visible');
-                        cy.contains('a', 'Delete').should('be.visible');
-                    }
+        cy.get('.govuk-table tbody').then(($tbody) => {
+            const rows = $tbody.find('tr[data-report-id]').toArray();
+        
+            rows.forEach((row) => {
+                cy.wrap(row).within(() => {
+                    cy.get('.govuk-tag').invoke('text').then((status) => {
+                        if (status.trim() === 'Complete') {
+                            cy.contains('a', 'Download report').should('be.visible');
+                            cy.contains('a', 'Delete').should('be.visible');
+                        }
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Summary

- Updated the historical reports Cypress test to allow a valid empty report table
- Retained completed-report action checks when historical rows exist
- Prevents the pipeline from depending on pre-existing report data

## Cause

The test used `cy.get()` for report rows, which fails when no historical reports
exist. The preceding lifecycle test deletes the report it creates, so an empty
history is valid in a clean pipeline environment.

## Testing

- AdminFSMReporting Cypress spec passes locally