### PR TITLE
ELIG-3368-ADMIN-FRONT-END-Implement-design-changes-to-show-correlation-ID-and-error-code-to-user-for-single-check-technical-error-outcomes

### DIFF
--- a/CheckYourEligibility.Admin.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/CheckControllerTests.cs
@@ -821,6 +821,31 @@ public class CheckControllerTests : TestBase
         _getCheckStatusUseCaseMock.Verify(x => x.Execute(responseJson, _sessionMock.Object), Times.Once);
     }
 
+    public async Task Given_Loader_When_Status_TechnicalError_Should_ReturnErrorCode()
+    {
+        // Arrange
+        var response = new CheckEligibilityResponse
+        {
+            Data = new StatusValue { Status = "error", ErrorCode = "TE21" }
+        };
+        var responseJson = JsonConvert.SerializeObject(response);
+        _sut.TempData["Response"] = responseJson;
+
+        _getCheckStatusUseCaseMock
+            .Setup(x => x.Execute(responseJson, _sessionMock.Object))
+            .ReturnsAsync(response.Data);
+
+        var ParentMock = _fixture.Create<ParentGuardian>();
+        _tempData["Response"] = null;
+
+        // Act
+        var result = await _sut.Loader(ParentMock);
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.ViewData["ErrorCode"].Should().Be(response.Data.ErrorCode);
+    }
+
     [Test]
     public async Task Given_Poll_Status_When_Response_Is_Null_Returns_Error_Status()
     {

--- a/CheckYourEligibility.Admin/Boundary/Responses/CheckEligibilityStatusResponse.cs
+++ b/CheckYourEligibility.Admin/Boundary/Responses/CheckEligibilityStatusResponse.cs
@@ -10,4 +10,6 @@ public class StatusValue
     public string Status { get; set; }
     public string Tier { get; set; }
     public string? EligibilityEndDate { get; set; }
+    public string ErrorCode { get; set; }
+    public string CorrelationID { get; set; }
 }

--- a/CheckYourEligibility.Admin/Controllers/CheckController.cs
+++ b/CheckYourEligibility.Admin/Controllers/CheckController.cs
@@ -153,7 +153,6 @@ public class CheckController : BaseController
         var responseJson = TempData["Response"] as string;
         try
         {
-
             // Cache the organisation type for use in the view
             OrganisationCategory organisationType = _Claims.Organisation.Category.Id;
             TempData["organisationType"] = organisationType;
@@ -206,6 +205,8 @@ public class CheckController : BaseController
                 case "parentNotFound":
                     return View("Outcome/Not_Found");
                 default:
+                    ViewData["CorellationID"] = outcome.CorrelationID;
+                    ViewData["ErrorCode"] = outcome.ErrorCode;
                     return View("Outcome/Technical_Error");
             }
         }

--- a/CheckYourEligibility.Admin/Usecases/GetCheckStatusUseCase.cs
+++ b/CheckYourEligibility.Admin/Usecases/GetCheckStatusUseCase.cs
@@ -40,6 +40,14 @@ public class GetCheckStatusUseCase : IGetCheckStatusUseCase
             throw new Exception("Null response received from GetStatus.");
         }
 
+        if (response.Links != null)
+        {
+            if (response.Links.Get_EligibilityCheck != null)
+            {
+                check.Data.CorrelationID = response.Links.Get_EligibilityCheck.Replace("/check/", "");
+            }
+        }
+
         _logger.LogInformation($"Received status: {check.Data.Status}");
         session.SetString("CheckResult", check.Data.Status);
 

--- a/CheckYourEligibility.Admin/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility.Admin/Views/Check/Outcome/Technical_Error.cshtml
@@ -1,5 +1,7 @@
 @{
     ViewData["Title"] = "Check failed";
+    string correlationID = ViewData["CorellationID"]?.ToString();
+    string errorCode = ViewData["ErrorCode"]?.ToString();
 }
 
 @inject IConfiguration Configuration
@@ -12,8 +14,10 @@
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
                  data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title"
-                        id="govuk-notification-banner-title">@ViewData["Title"]</h2>
+                    <h1 class="govuk-notification-banner__title"
+                        id="govuk-notification-banner-title">
+                        @ViewData["Title"]
+                    </h1>
                 </div>
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
@@ -24,8 +28,17 @@
                 </div>
             </div>
 
-            <h1 class="govuk-heading-l">If the check keeps failing</h1>
-            <a>Contact the <a href="@Configuration["ContactUsUrl"]"> Department for Education support desk.</a>
+            <h2>How to report this error</h2>
+            <p>Copy the following details and send them to our team using the <a target="_blank" href="https://customerhelpportal.education.gov.uk/">Customer Help Portal</a>.</p>
+            @if (correlationID != null)
+            {
+                <p>Correlation ID: @correlationID</p>
+            }
+            <p>Error code: @errorCode</p>
+            <p>Please copy and paste the details rather than sending a screenshot.</p>
+
+            <h2 class="govuk-heading-l">If the check keeps failing</h2>
+            <p>Contact the <a href="@Configuration["ContactUsUrl"]"> Department for Education support desk.</a>
         </div>
     </div>
 </div>

--- a/tests/cypress/e2e/Admin/TechnicalError.spec.SKIP.ts
+++ b/tests/cypress/e2e/Admin/TechnicalError.spec.SKIP.ts
@@ -1,0 +1,40 @@
+//Test set as SKIP due to the length of time a tech error response takes to return, so we do not want to
+//  include this in regular test runs. The timeout is set to how long it will keep checking rather than a 
+// fixed wait, but our intention is to see if we can generate the response faster before including
+// this test more permanently. Then just remove SKIP from filename to re-enable it.
+
+describe('TechnicalError outcome should display Error Code and CorrelationID', () => {
+    const parentFirstName = 'Tim';
+    const parentLastName = Cypress.env('lastName');
+    const parentEmailAddress = 'TimJones@Example.com';
+
+    it('TechnicalError outcome should display Error Code and CorrelationID', () => {
+
+        cy.checkSession('school');
+        cy.visit((Cypress.config().baseUrl ?? "") + "/home");
+        cy.wait(1);
+        cy.get('.govuk-caption-l').should('include.text', 'The Telford Park School');
+
+        //Add parent details
+        cy.contains('Run a check for one parent or guardian').click();
+        cy.get('#consent').check();
+        cy.get('#submitButton').click();
+        cy.url().should('include', '/Check/Enter_Details');
+        cy.get('#FirstName').type(parentFirstName);
+        cy.get('#LastName').type(parentLastName);
+        cy.get('#EmailAddress').type(parentEmailAddress);
+        cy.get('[id="DateOfBirth.Day"]').type('01');
+        cy.get('[id="DateOfBirth.Month"]').type('01');
+        cy.get('[id="DateOfBirth.Year"]').type('1990');
+        cy.get('#NationalInsuranceNumber').type("XX123456C");
+        cy.contains('button', 'Perform check').click();
+
+        //Loader page
+        cy.url().should('include', 'Check/Loader');
+
+        //Technical_Error outcome
+        cy.get('h1',{ timeout: 120000 }).should('include.text', 'Check failed');
+        cy.get('body').should('include.text', 'Error code: STE50');
+        cy.get('body').should('include.text', 'Correlation ID:'); //Only shown if Guid was available from the check
+    });
+});


### PR DESCRIPTION
- Add Error Code and Correlation ID to the Technical_Error outcome for single checks.

https://dfedigital.atlassian.net/browse/ELIG-3368