### PR TITLE
ELIG-3556 Align FSM bulk name validation

### DIFF
--- a/CheckYourEligibility.Admin.Tests/Validators/CheckEligibilityRequestDataValidatorNameTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Validators/CheckEligibilityRequestDataValidatorNameTests.cs
@@ -1,0 +1,131 @@
+﻿using CheckYourEligibility.Admin.Boundary.Requests;
+using CheckYourEligibility.Admin.Domain.Constants.ErrorMessages;
+using CheckYourEligibility.Admin.Domain.Validation;
+using FluentValidation;
+
+namespace CheckYourEligibility.Admin.Tests.Validators;
+
+[TestFixture]
+public class CheckEligibilityRequestDataValidatorNameTests
+{
+    private IValidator<IEligibilityServiceType> _validator = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _validator = new CheckEligibilityRequestDataValidator();
+    }
+
+    [TestCase("García")]
+    [TestCase("O'Connor")]
+    [TestCase("O’Connor")]
+    [TestCase("Smith-Jones")]
+    public async Task Validate_BasicSupportedLastName_Passes(string lastName)
+    {
+        var request = CreateValidBasicRequest();
+        request.LastName = lastName;
+
+        var result = await _validator.ValidateAsync(request);
+
+        Assert.That(result.Errors, Is.Empty);
+    }
+
+    [Test]
+    public async Task Validate_BasicUnsupportedLastName_ReturnsInvalidCharacterMessage()
+    {
+        var request = CreateValidBasicRequest();
+        request.LastName = "Smith@";
+
+        var result = await _validator.ValidateAsync(request);
+
+        Assert.That(
+            result.Errors.Select(x => x.ErrorMessage),
+            Is.EqualTo(new[] { ValidationMessages.InvalidLastName }));
+    }
+
+    [Test]
+    public async Task Validate_BasicMissingLastName_ReturnsOnlyRequiredMessage()
+    {
+        var request = CreateValidBasicRequest();
+        request.LastName = string.Empty;
+
+        var result = await _validator.ValidateAsync(request);
+
+        Assert.That(
+            result.Errors.Select(x => x.ErrorMessage),
+            Is.EqualTo(new[] { ValidationMessages.LastName }));
+    }
+
+    [Test]
+    public async Task Validate_EnhancedSupportedNames_Passes()
+    {
+        var request = CreateValidEnhancedRequest();
+        request.FirstName = "José";
+        request.LastName = "García";
+        request.ChildFirstName = "Zoë";
+        request.ChildLastName = "O'Connor";
+
+        var result = await _validator.ValidateAsync(request);
+
+        Assert.That(result.Errors, Is.Empty);
+    }
+
+    [TestCase(nameof(CheckEligibilityRequestData_Enhanced.FirstName),
+        ValidationMessages.InvalidFirstName)]
+    [TestCase(nameof(CheckEligibilityRequestData_Enhanced.LastName),
+        ValidationMessages.InvalidLastName)]
+    [TestCase(nameof(CheckEligibilityRequestData_Enhanced.ChildFirstName),
+        ValidationMessages.InvalidChildFirstName)]
+    [TestCase(nameof(CheckEligibilityRequestData_Enhanced.ChildLastName),
+        ValidationMessages.InvalidChildLastName)]
+    public async Task Validate_EnhancedUnsupportedName_ReturnsInvalidCharacterMessage(
+        string propertyName,
+        string expectedMessage)
+    {
+        var request = CreateValidEnhancedRequest();
+        SetName(request, propertyName, "Smith@");
+
+        var result = await _validator.ValidateAsync(request);
+
+        Assert.That(
+            result.Errors.Select(x => x.ErrorMessage),
+            Is.EqualTo(new[] { expectedMessage }));
+    }
+
+    private static CheckEligibilityRequestDataBase CreateValidBasicRequest()
+    {
+        return new CheckEligibilityRequestDataBase
+        {
+            LastName = "Smith",
+            DateOfBirth = "1985-04-23",
+            NationalInsuranceNumber = "AA123456C",
+            Sequence = 1
+        };
+    }
+
+    private static CheckEligibilityRequestData_Enhanced CreateValidEnhancedRequest()
+    {
+        return new CheckEligibilityRequestData_Enhanced
+        {
+            FirstName = "John",
+            LastName = "Smith",
+            DateOfBirth = "1985-04-23",
+            NationalInsuranceNumber = "AA123456C",
+            ChildFirstName = "Emily",
+            ChildLastName = "Smith",
+            ChildDateOfBirth = "2015-09-10",
+            ChildSchoolUrn = "123456",
+            Sequence = 1
+        };
+    }
+
+    private static void SetName(
+        CheckEligibilityRequestData_Enhanced request,
+        string propertyName,
+        string value)
+    {
+        typeof(CheckEligibilityRequestData_Enhanced)
+            .GetProperty(propertyName)!
+            .SetValue(request, value);
+    }
+}

--- a/CheckYourEligibility.Admin/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
+++ b/CheckYourEligibility.Admin/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
@@ -15,4 +15,8 @@ public static class ValidationMessages
     public const string ChildDOB = "Child Date of birth is required:- (yyyy-mm-dd)";
     public const string InvalidSchoolUrnForLA = "School URN must be for a school in your local authority area";
     public const string InvalidSchoolUrnForMAT = "School URN must be for a school in your MAT";
+    public const string InvalidFirstName = "Parent First Name contains an invalid character";
+    public const string InvalidLastName = "Parent Last Name contains an invalid character";
+    public const string InvalidChildFirstName = "Child First Name contains an invalid character";
+    public const string InvalidChildLastName = "Child Last Name contains an invalid character";
 }

--- a/CheckYourEligibility.Admin/Domain/Validation/CheckEligibilityRequestDataValidator.cs
+++ b/CheckYourEligibility.Admin/Domain/Validation/CheckEligibilityRequestDataValidator.cs
@@ -20,10 +20,11 @@ public class CheckEligibilityRequestDataValidator : AbstractValidator<IEligibili
                 .ChildRules(baseValidator =>
                 {
                     baseValidator.RuleFor(x => x.LastName)
+                        .Cascade(CascadeMode.Stop)
                         .NotEmpty()
                         .WithMessage(ValidationMessages.LastName)
                         .Must(DataValidation.BeAValidName)
-                        .WithMessage(ValidationMessages.LastName);
+                        .WithMessage(ValidationMessages.InvalidLastName);
 
                     // DOB (required + valid)
                     baseValidator.RuleFor(x => x.DateOfBirth)
@@ -51,24 +52,27 @@ public class CheckEligibilityRequestDataValidator : AbstractValidator<IEligibili
                 {
                     // First Name (required + valid)
                     enhanced.RuleFor(x => x.FirstName)
+                        .Cascade(CascadeMode.Stop)
                         .NotEmpty()
                         .WithMessage(ValidationMessages.FirstName)
                         .Must(DataValidation.BeAValidName)
-                        .WithMessage(ValidationMessages.FirstName);
+                        .WithMessage(ValidationMessages.InvalidFirstName);
 
                     // Child First Name (required + valid)
                     enhanced.RuleFor(x => x.ChildFirstName)
+                        .Cascade(CascadeMode.Stop)
                         .NotEmpty()
                         .WithMessage(ValidationMessages.ChildFirstName)
                         .Must(DataValidation.BeAValidName)
-                        .WithMessage(ValidationMessages.ChildFirstName);
+                        .WithMessage(ValidationMessages.InvalidChildFirstName);
 
                     // Child Last Name (required + valid)
                     enhanced.RuleFor(x => x.ChildLastName)
+                        .Cascade(CascadeMode.Stop)
                         .NotEmpty()
                         .WithMessage(ValidationMessages.ChildLastName)
                         .Must(DataValidation.BeAValidName)
-                        .WithMessage(ValidationMessages.ChildLastName);
+                        .WithMessage(ValidationMessages.InvalidChildLastName);
 
                     // Child DOB (required + valid)
                     enhanced.RuleFor(x => x.ChildDateOfBirth)

--- a/CheckYourEligibility.Admin/Domain/Validation/DataValidation.cs
+++ b/CheckYourEligibility.Admin/Domain/Validation/DataValidation.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using CheckYourEligibility.Admin.Attributes;
 
 namespace CheckYourEligibility.API.Domain.Validation;
 
@@ -24,14 +25,14 @@ internal static class DataValidation
         return res.Success;
     }
 
-    internal static bool BeAValidName(string value)
+    internal static bool BeAValidName(string? value)
     {
-        var regexString =
-            @"^[a-zA-Z ,.''\u2018\u2019-]+$";
-        var rg = new Regex(regexString);
-        var res = rg.Match(value);
-        return res.Success;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        return Regex.IsMatch(value, NameAttribute.NameValidationRegex);
     }
+
     internal static bool BeAValidDate(string value)
     {
         var regexString =


### PR DESCRIPTION
## Summary

* Aligns FSM bulk name validation with the supported accented-character set already used by single checks.
* Reuses `NameAttribute.NameValidationRegex` instead of maintaining a separate bulk-check regex.
* Distinguishes required-name errors from invalid-character errors.
* Preserves support for straight and curly apostrophes and hyphens.
* Adds automated coverage for Basic and Enhanced bulk name fields.

## Testing

* New name-validation tests: 11 passed.
* Existing Enhanced validator tests: 9 passed.
* Full test suite: 257 passed.

Manual verification completed for:

* Basic FSM
* Enhanced Local Authority
* Enhanced School

Confirmed that `García` is accepted, `Smith@` receives an invalid-character message, and an empty surname receives the required-field message.
