### PR TITLE
ELIG-3194 Display FSM batch results in uploaded order

### DIFF
--- a/CheckYourEligibility.Admin.Tests/Controllers/BulkUploadTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Controllers/BulkUploadTests.cs
@@ -127,7 +127,7 @@ public class BulkUploadTests : TestBase
                     LastName = "Smith",
                     DateOfBirth = "1985-03-15",
                     NationalInsuranceNumber = "AB123456C",
-                    Sequence = 1
+                    Order = 1
                 }
             }
         };
@@ -214,7 +214,7 @@ public class BulkUploadTests : TestBase
                     LastName = "Smith",
                     DateOfBirth = "1985-03-15",
                     NationalInsuranceNumber = "AB123456C",
-                    Sequence = 1
+                    Order = 1
                 }
             }
         };

--- a/CheckYourEligibility.Admin.Tests/Gateways/CheckGatewayTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Gateways/CheckGatewayTests.cs
@@ -2,6 +2,7 @@
 using AutoMapper;
 using CheckYourEligibility.Admin.Boundary.Requests;
 using CheckYourEligibility.Admin.Boundary.Responses;
+using CheckYourEligibility.Admin.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -201,5 +202,53 @@ internal class CheckGatewayTests
         // Assert
         result.Result.Data.Should().BeNull();
         _sut.apiErrorCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task LoadBulkCheckResults_ReturnsResultsInUploadedOrder()
+    {
+        var responseContent = new CheckEligibilityBulkResponse
+        {
+            Data =
+            [
+                new CheckEligibilityItem
+                {
+                    Order = 2,
+                    LastName = "SECOND"
+                },
+                new CheckEligibilityItem
+                {
+                    Order = 1,
+                    LastName = "FIRST"
+                }
+            ]
+        };
+
+        var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(JsonConvert.SerializeObject(responseContent))
+        };
+
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(responseMessage);
+
+        _mapperMock
+            .Setup(x => x.Map<BulkExportBase>(It.IsAny<CheckEligibilityItem>()))
+            .Returns((CheckEligibilityItem source) => new BulkExportBase
+            {
+                LastName = source.LastName
+            });
+
+        var result = (await _sut.LoadBulkCheckResults<BulkExportBase>("bulk-id"))
+            .ToList();
+
+        result.Select(x => x.LastName)
+            .Should()
+            .Equal("FIRST", "SECOND");
     }
 }

--- a/CheckYourEligibility.Admin.Tests/Validators/CheckEligibilityEnhancedValidatorTests.cs
+++ b/CheckYourEligibility.Admin.Tests/Validators/CheckEligibilityEnhancedValidatorTests.cs
@@ -34,7 +34,7 @@ namespace CheckYourEligibility.Admin.Tests.Validators
                 LastName = "Test",
                 FirstName = "Test",
                 DateOfBirth = "1985-04-23",
-                Sequence = 1,
+                Order = 1,
 
                 ChildFirstName = "Emily",
                 ChildLastName = "Test",
@@ -58,7 +58,7 @@ namespace CheckYourEligibility.Admin.Tests.Validators
                 LastName = "Test",
                 FirstName = "Test",
                 DateOfBirth = "1985-04-23",
-                Sequence = 1,
+                Order = 1,
 
                 ChildFirstName = "Emily",
                 ChildLastName = "Test",
@@ -86,7 +86,7 @@ namespace CheckYourEligibility.Admin.Tests.Validators
                 LastName = "Test",
                 FirstName = "Test",
                 DateOfBirth = "1985-04-23",
-                Sequence = 1,
+                Order = 1,
 
                 ChildFirstName = "Emily",
                 ChildLastName = "Test",
@@ -115,7 +115,7 @@ namespace CheckYourEligibility.Admin.Tests.Validators
                 FirstName = "Test",
                 LastName = "Test",
                 DateOfBirth = "1985-04-23",
-                Sequence = 1,
+                Order = 1,
 
                 ChildFirstName = "Emily",
                 ChildLastName = "Test",
@@ -142,7 +142,7 @@ namespace CheckYourEligibility.Admin.Tests.Validators
                 FirstName = "Test",
                 LastName = "Test",
                 DateOfBirth = "1985-04-23",
-                Sequence = 1,
+                Order = 1,
 
                 ChildFirstName = "Emily",
                 ChildLastName = "Test",

--- a/CheckYourEligibility.Admin/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.Admin/Boundary/Requests/CheckEligibilityRequest.cs
@@ -9,7 +9,7 @@ public class CheckEligibilityRequestDataBase : IEligibilityServiceType
     public string? NationalInsuranceNumber { get; set; }
     public string LastName { get; set; } = string.Empty;
     public string DateOfBirth { get; set; } = string.Empty;
-    public int? Sequence { get; set; }
+    public int? Order { get; set; }
 }
 public class CheckEligibilityRequestBulkBase {
 

--- a/CheckYourEligibility.Admin/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckYourEligibility.Admin/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -22,7 +22,7 @@ public class CheckEligibilityItem
     public string? ChildLastName { get; set; }
     public string? ChildDateOfBirth { get; set; }
     public string? ChildSchoolUrn { get; set; }
-
+    public int? Order { get; set; }
 }
 
 public class CheckEligibilityItemResponse

--- a/CheckYourEligibility.Admin/Gateways/CheckGateway.cs
+++ b/CheckYourEligibility.Admin/Gateways/CheckGateway.cs
@@ -227,7 +227,9 @@ public class CheckGateway : BaseGateway, ICheckGateway
             }
             else
             {
-                return response.Data.Select(x => _mapper.Map<TBulkExport>(x));
+                return response.Data
+                    .OrderBy(x => x.Order)
+                    .Select(x => _mapper.Map<TBulkExport>(x));
             }
         }
         catch (Exception ex)

--- a/CheckYourEligibility.Admin/Helpers/CsvBulkCheckValidatorHelper.cs
+++ b/CheckYourEligibility.Admin/Helpers/CsvBulkCheckValidatorHelper.cs
@@ -117,7 +117,7 @@ namespace CheckYourEligibility.Admin.Helpers
                 LastName = csv.GetField(ParentLastNameHeader)?.Trim() ?? string.Empty,
                 DateOfBirth = ParseDate(dob),
                 NationalInsuranceNumber = csv.GetField(ParentNINOHeader)?.Trim().ToUpper(),
-                Sequence = sequence
+                Order = sequence
             };
         }
 
@@ -133,7 +133,7 @@ namespace CheckYourEligibility.Admin.Helpers
                 ChildLastName = csv.GetField(ChildLastNameHeader)?.Trim() ?? string.Empty,
                 ChildDateOfBirth = ParseDate(csv.GetField(ChildDateOfBirthHeader)),
                 ChildSchoolUrn = csv.GetField(ChildSchoolUrnHeader)?.Trim() ?? string.Empty,
-                Sequence = sequence
+                Order = sequence
             };
         }
 
@@ -149,7 +149,7 @@ namespace CheckYourEligibility.Admin.Helpers
                 ChildLastName = csv.GetField(ChildLastNameHeader)?.Trim() ?? string.Empty,
                 ChildDateOfBirth = ParseDate(csv.GetField(ChildDateOfBirthHeader)),
                 ChildSchoolUrn = schoolUrn,
-                Sequence = sequence
+                Order = sequence
             };
         }
         /// <summary>

--- a/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBasicBulkCheckJourney.spec.ts
@@ -122,7 +122,7 @@ it("will run a successful batch check", () => {
     .then(($row) => {
       cy.wrap($row).find("td").eq(0).invoke("text").should("match", /\.csv$/i);
       cy.wrap($row).find("td").eq(1).should("have.text", "15");
-      cy.wrap($row).find("td").eq(2).should("have.text", "Tester");
+      cy.wrap($row).find("td").eq(2).should("have.text", "TESTER");
       cy.wrap($row).find("td").eq(3).should("contain.text", today);
       cy.wrap($row).find("td").eq(4).invoke("text").should("not.be.empty");
       cy.wrap($row).find("td").eq(5).find("strong").should("have.class", "govuk-tag");

--- a/tests/cypress/e2e/Admin/AdminBulkCheckJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminBulkCheckJourney.spec.ts
@@ -130,7 +130,7 @@ Object.entries(sessionConfigs).forEach(([sessionType, config]) => {
             .invoke("text")
             .should("match", /\.csv$/i);
           cy.get("td").eq(1).should("have.text", "10");
-          cy.get("td").eq(2).should("have.text", "Smith");
+          cy.get("td").eq(2).should("have.text", "SMITH");
           cy.get("td").eq(3).should("contain.text", today);
           cy.get("td").eq(4).invoke("text").should("not.be.empty");
           cy.get("td").eq(5).find("strong").should("have.class", "govuk-tag");


### PR DESCRIPTION
## Summary

- Replaces the obsolete frontend `Sequence` property with the new internal `Order` value.
- Assigns `Order` from the original CSV row position for:
  - FSM Basic
  - FSM Enhanced School
  - FSM Enhanced LA/MAT
- Reads `Order` from completed API bulk results.
- Sorts results by `Order` before AutoMapper creates the CSV export records.
- Does not add an Order column to the downloaded CSV.

## Reason

Asynchronous processing can return FSM batch results in a different order from the uploaded file. Local authorities need outcome rows to retain their original upload sequence so they can reliably align results with their own records.

## Testing

- Full FSM Admin unit-test suite: 247 passed
- 0 failed
- 0 skipped
- Added gateway regression coverage proving results are sorted before export mapping.
- Existing Basic and Enhanced upload and validation tests updated for `Order`.

## Dependency

Depends on the supporting API change:

- [eligibility-checking-engine #529](https://github.com/DFE-Digital/eligibility-checking-engine/pull/529)

The API change must be deployed before, or alongside, this frontend change.